### PR TITLE
Msg 38

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -382,14 +382,6 @@
       <version>1.78.1</version>
     </dependency>
 
-
-    <!-- https://mvnrepository.com/artifact/com.google.code.gson/gson -->
-      <dependency>
-          <groupId>com.google.code.gson</groupId>
-          <artifactId>gson</artifactId>
-          <version>2.10.1</version>
-      </dependency>
-
     <!-- https://mvnrepository.com/artifact/com.fasterxml.uuid/java-uuid-generator -->
     <dependency>
       <groupId>com.fasterxml.uuid</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -375,8 +375,15 @@
       <artifactId>bcprov-jdk18on</artifactId>
       <version>1.78.1</version>
     </dependency>
+    <!-- https://mvnrepository.com/artifact/org.bouncycastle/bcpkix-jdk18on -->
+    <dependency>
+      <groupId>org.bouncycastle</groupId>
+      <artifactId>bcpkix-jdk18on</artifactId>
+      <version>1.78.1</version>
+    </dependency>
 
-      <!-- https://mvnrepository.com/artifact/com.google.code.gson/gson -->
+
+    <!-- https://mvnrepository.com/artifact/com.google.code.gson/gson -->
       <dependency>
           <groupId>com.google.code.gson</groupId>
           <artifactId>gson</artifactId>

--- a/src/main/java/io/mapsmessaging/security/access/Identity.java
+++ b/src/main/java/io/mapsmessaging/security/access/Identity.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright [ 2020 - 2024 ] [Matthew Buckton]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.mapsmessaging.security.access;
+
+import io.mapsmessaging.security.identity.GroupEntry;
+import io.mapsmessaging.security.identity.IdentityEntry;
+import lombok.Getter;
+import lombok.ToString;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+@Getter
+@ToString
+public class Identity {
+
+  private final String username;
+  private final Map<String, String> attributes;
+  private final List<GroupEntry> groupList;
+
+  public Identity(IdentityEntry identityEntry) {
+    username = identityEntry.getUsername();
+    groupList = identityEntry.getGroups();
+    attributes = buildAttributes(identityEntry);
+  }
+
+  private Map<String, String> buildAttributes(IdentityEntry identityEntry) {
+    Map<String, String> map = new LinkedHashMap<>();
+    identityEntry.setAttributeMap(map);
+    return map;
+  }
+
+}

--- a/src/main/java/io/mapsmessaging/security/access/IdentityAccessManager.java
+++ b/src/main/java/io/mapsmessaging/security/access/IdentityAccessManager.java
@@ -51,7 +51,9 @@ public class IdentityAccessManager {
   private final GroupMapManagement groupMapManagement;
   private final UserMapManagement userMapManagement;
 
-  @Getter @Setter private PasswordHandler passwordHandler;
+  @Getter
+  @Setter
+  private PasswordHandler passwordHandler;
 
   public IdentityAccessManager(
       String identity,
@@ -282,5 +284,9 @@ public class IdentityAccessManager {
       }
     }
     return userIdMap;
+  }
+
+  public void setAsSystemIdentityLookup(){
+    IdentityLookupFactory.getInstance().registerSiteIdentityLookup("system", identityLookup);
   }
 }

--- a/src/main/java/io/mapsmessaging/security/access/IdentityAccessManager.java
+++ b/src/main/java/io/mapsmessaging/security/access/IdentityAccessManager.java
@@ -33,10 +33,6 @@ import io.mapsmessaging.security.passwords.PasswordHandler;
 import io.mapsmessaging.security.passwords.PasswordHandlerFactory;
 import io.mapsmessaging.security.passwords.ciphers.EncryptedPasswordCipher;
 import io.mapsmessaging.security.uuid.UuidGenerator;
-import lombok.Getter;
-import lombok.Setter;
-
-import javax.security.auth.Subject;
 import java.io.IOException;
 import java.security.GeneralSecurityException;
 import java.security.Principal;
@@ -44,6 +40,9 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import javax.security.auth.Subject;
+import lombok.Getter;
+import lombok.Setter;
 
 public class IdentityAccessManager {
 
@@ -267,6 +266,7 @@ public class IdentityAccessManager {
       groupMapManagement.save();
     }
     return true;
+
   }
 
   private UserIdMap mapUser(IdentityEntry entry) {

--- a/src/main/java/io/mapsmessaging/security/access/IdentityAccessManager.java
+++ b/src/main/java/io/mapsmessaging/security/access/IdentityAccessManager.java
@@ -153,16 +153,15 @@ public class IdentityAccessManager {
     return identityLookup.findGroup(groupName);
   }
 
-  public UserIdMap createUser(String username, String hash)
+  public UserIdMap createUser(String username, char[] passwordHash)
       throws IOException, GeneralSecurityException {
     IdentityEntry entry = identityLookup.findEntry(username);
+    if (entry != null) {
+      throw new GeneralSecurityException("User already exists");
+    }
+    identityLookup.createUser(username, passwordHash, passwordHandler);
+
     UserIdMap idMap = userMapManagement.get(identityLookup.getDomain() + ":" + username);
-    if (entry != null && idMap != null) {
-      return idMap;
-    }
-    if (entry == null) {
-      identityLookup.createUser(username, hash, passwordHandler);
-    }
     if (idMap == null) {
       idMap = new UserIdMap(UuidGenerator.getInstance().generate(), username, identityLookup.getDomain());
       userMapManagement.add(idMap);
@@ -171,7 +170,7 @@ public class IdentityAccessManager {
     return idMap;
   }
 
-  public boolean updateUserPassword(String username, String hash, PasswordHandler passwordHasher)
+  public boolean updateUserPassword(String username, char[] hash, PasswordHandler passwordHasher)
       throws IOException, GeneralSecurityException {
     if (identityLookup.findEntry(username) != null) {
       identityLookup.deleteUser(username);

--- a/src/main/java/io/mapsmessaging/security/access/IdentityAccessManager.java
+++ b/src/main/java/io/mapsmessaging/security/access/IdentityAccessManager.java
@@ -29,6 +29,7 @@ import io.mapsmessaging.security.identity.IdentityLookupFactory;
 import io.mapsmessaging.security.identity.impl.encrypted.EncryptedAuth;
 import io.mapsmessaging.security.identity.principals.GroupIdPrincipal;
 import io.mapsmessaging.security.identity.principals.UniqueIdentifierPrincipal;
+import io.mapsmessaging.security.passwords.PasswordBuffer;
 import io.mapsmessaging.security.passwords.PasswordHandler;
 import io.mapsmessaging.security.passwords.PasswordHandlerFactory;
 import io.mapsmessaging.security.passwords.ciphers.EncryptedPasswordCipher;
@@ -36,10 +37,7 @@ import io.mapsmessaging.security.uuid.UuidGenerator;
 import java.io.IOException;
 import java.security.GeneralSecurityException;
 import java.security.Principal;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 import javax.security.auth.Subject;
 import lombok.Getter;
 import lombok.Setter;
@@ -150,6 +148,19 @@ public class IdentityAccessManager {
 
   public GroupIdMap getGroup(String groupName) {
     return groupMapManagement.get(identityLookup.getDomain() + ":" + groupName);
+  }
+
+  public boolean validateUser(String username, char[] passwordHash) throws IOException {
+    IdentityEntry entry = identityLookup.findEntry(username);
+    if (entry != null) {
+      try {
+        PasswordBuffer passwordTest = entry.getPasswordHasher().getPassword();
+        return Arrays.equals(passwordHash, passwordTest.getHash());
+      } catch (GeneralSecurityException e) {
+        throw new IOException(e);
+      }
+    }
+    return false;
   }
 
   public UserIdMap createUser(String username, char[] passwordHash)

--- a/src/main/java/io/mapsmessaging/security/identity/IdentityEntry.java
+++ b/src/main/java/io/mapsmessaging/security/identity/IdentityEntry.java
@@ -19,12 +19,13 @@ package io.mapsmessaging.security.identity;
 import com.sun.security.auth.UserPrincipal;
 import io.mapsmessaging.security.identity.principals.GroupPrincipal;
 import io.mapsmessaging.security.passwords.PasswordHandler;
+import lombok.Getter;
+
+import javax.security.auth.Subject;
 import java.io.IOException;
 import java.security.GeneralSecurityException;
 import java.security.Principal;
 import java.util.*;
-import javax.security.auth.Subject;
-import lombok.Getter;
 
 /**
  * Represents an identity entry, which can be a user or a machine-to-machine username.
@@ -114,5 +115,9 @@ public class IdentityEntry {
   @SuppressWarnings("java:S1130") // They are thrown by inherited classes
   public char[] getPassword() throws GeneralSecurityException, IOException {
     return password;
+  }
+
+  public void setAttributeMap(Map<String, String> attributeMap) {
+
   }
 }

--- a/src/main/java/io/mapsmessaging/security/identity/IdentityEntry.java
+++ b/src/main/java/io/mapsmessaging/security/identity/IdentityEntry.java
@@ -18,8 +18,8 @@ package io.mapsmessaging.security.identity;
 
 import com.sun.security.auth.UserPrincipal;
 import io.mapsmessaging.security.identity.principals.GroupPrincipal;
+import io.mapsmessaging.security.passwords.PasswordBuffer;
 import io.mapsmessaging.security.passwords.PasswordHandler;
-import io.mapsmessaging.security.util.ArrayHelper;
 import java.io.IOException;
 import java.security.GeneralSecurityException;
 import java.security.Principal;
@@ -71,7 +71,7 @@ public class IdentityEntry implements Cloneable {
   @Getter
   protected PasswordHandler passwordHasher;
 
-  protected char[] password;
+  protected PasswordBuffer password;
 
   public boolean isInGroup(String group) {
     return groupList.containsKey(group);
@@ -105,7 +105,7 @@ public class IdentityEntry implements Cloneable {
 
   @Override
   public String toString() {
-    return username + ":" + new String(password);
+    return username + ":" + new String(password.getHash());
   }
 
   public void removeGroup(GroupEntry groupEntry) {
@@ -113,7 +113,7 @@ public class IdentityEntry implements Cloneable {
   }
 
   @SuppressWarnings("java:S1130") // They are thrown by inherited classes
-  public char[] getPassword() throws GeneralSecurityException, IOException {
+  public PasswordBuffer getPassword() throws GeneralSecurityException, IOException {
     return password;
   }
 
@@ -129,7 +129,7 @@ public class IdentityEntry implements Cloneable {
 
   public IdentityEntry clone() throws CloneNotSupportedException {
     IdentityEntry identityEntry = this.clone();
-    ArrayHelper.clearCharArray(identityEntry.password);
+    identityEntry.password.clear();
     return identityEntry;
   }
 

--- a/src/main/java/io/mapsmessaging/security/identity/IdentityEntry.java
+++ b/src/main/java/io/mapsmessaging/security/identity/IdentityEntry.java
@@ -19,13 +19,13 @@ package io.mapsmessaging.security.identity;
 import com.sun.security.auth.UserPrincipal;
 import io.mapsmessaging.security.identity.principals.GroupPrincipal;
 import io.mapsmessaging.security.passwords.PasswordHandler;
-import lombok.Getter;
-
-import javax.security.auth.Subject;
+import io.mapsmessaging.security.util.ArrayHelper;
 import java.io.IOException;
 import java.security.GeneralSecurityException;
 import java.security.Principal;
 import java.util.*;
+import javax.security.auth.Subject;
+import lombok.Getter;
 
 /**
  * Represents an identity entry, which can be a user or a machine-to-machine username.
@@ -63,7 +63,7 @@ import java.util.*;
  * @see GroupEntry
  * @see Subject
  */
-public class IdentityEntry {
+public class IdentityEntry implements Cloneable {
 
   protected final Map<String, GroupEntry> groupList = new LinkedHashMap<>();
   @Getter
@@ -115,6 +115,22 @@ public class IdentityEntry {
   @SuppressWarnings("java:S1130") // They are thrown by inherited classes
   public char[] getPassword() throws GeneralSecurityException, IOException {
     return password;
+  }
+
+  public IdentityEntry secure() {
+    try{
+      return clone();
+    }
+    catch (CloneNotSupportedException e){
+      // it is
+    }
+    return null;
+  }
+
+  public IdentityEntry clone() throws CloneNotSupportedException {
+    IdentityEntry identityEntry = this.clone();
+    ArrayHelper.clearCharArray(identityEntry.password);
+    return identityEntry;
   }
 
   public void setAttributeMap(Map<String, String> attributeMap) {

--- a/src/main/java/io/mapsmessaging/security/identity/IdentityEntry.java
+++ b/src/main/java/io/mapsmessaging/security/identity/IdentityEntry.java
@@ -70,7 +70,7 @@ public class IdentityEntry {
   @Getter
   protected PasswordHandler passwordHasher;
 
-  protected String password;
+  protected char[] password;
 
   public boolean isInGroup(String group) {
     return groupList.containsKey(group);
@@ -104,7 +104,7 @@ public class IdentityEntry {
 
   @Override
   public String toString() {
-    return username + ":" + password;
+    return username + ":" + new String(password);
   }
 
   public void removeGroup(GroupEntry groupEntry) {
@@ -112,7 +112,7 @@ public class IdentityEntry {
   }
 
   @SuppressWarnings("java:S1130") // They are thrown by inherited classes
-  public String getPassword() throws GeneralSecurityException, IOException {
+  public char[] getPassword() throws GeneralSecurityException, IOException {
     return password;
   }
 }

--- a/src/main/java/io/mapsmessaging/security/identity/IdentityLookup.java
+++ b/src/main/java/io/mapsmessaging/security/identity/IdentityLookup.java
@@ -52,7 +52,7 @@ public interface IdentityLookup {
     throw new NotImplementedException("Unable to delete groups");
   }
 
-  default boolean createUser(String username, String passwordHash, PasswordHandler passwordHasher)
+  default boolean createUser(String username, char[] passwordHash, PasswordHandler passwordHasher)
       throws IOException, GeneralSecurityException {
     throw new NotImplementedException("Unable to add users to an LDAP server");
   }

--- a/src/main/java/io/mapsmessaging/security/identity/IdentityLookup.java
+++ b/src/main/java/io/mapsmessaging/security/identity/IdentityLookup.java
@@ -17,6 +17,7 @@
 package io.mapsmessaging.security.identity;
 
 import io.mapsmessaging.configuration.ConfigurationProperties;
+import io.mapsmessaging.security.passwords.PasswordBuffer;
 import io.mapsmessaging.security.passwords.PasswordHandler;
 import java.io.IOException;
 import java.security.GeneralSecurityException;
@@ -30,7 +31,7 @@ public interface IdentityLookup {
 
   String getDomain();
 
-  char[] getPasswordHash(String username) throws IOException, GeneralSecurityException;
+  PasswordBuffer getPasswordHash(String username) throws IOException, GeneralSecurityException;
 
   IdentityEntry findEntry(String username);
 
@@ -63,5 +64,9 @@ public interface IdentityLookup {
 
   default void updateGroup(GroupEntry groupEntry) throws IOException {
     throw new NotImplementedException("Unable to delete users to an LDAP server");
+  }
+
+  default boolean canManage(){
+    return false;
   }
 }

--- a/src/main/java/io/mapsmessaging/security/identity/impl/apache/ApacheBasicAuth.java
+++ b/src/main/java/io/mapsmessaging/security/identity/impl/apache/ApacheBasicAuth.java
@@ -21,11 +21,11 @@ import io.mapsmessaging.security.identity.*;
 import io.mapsmessaging.security.identity.impl.base.FileBaseGroups;
 import io.mapsmessaging.security.identity.impl.base.FileBaseIdentities;
 import io.mapsmessaging.security.passwords.PasswordHandler;
-
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.security.GeneralSecurityException;
+import java.util.ArrayList;
 import java.util.List;
 
 public class ApacheBasicAuth implements IdentityLookup {
@@ -80,23 +80,34 @@ public class ApacheBasicAuth implements IdentityLookup {
 
   @Override
   public GroupEntry findGroup(String groupName) {
-    return groupFileManager.findGroup(groupName);
+    if (groupFileManager != null) {
+      return groupFileManager.findGroup(groupName);
+    }
+    return null;
   }
 
   @Override
   public List<GroupEntry> getGroups() {
-    return groupFileManager.getGroups();
+    if (groupFileManager != null) {
+      return groupFileManager.getGroups();
+    }
+    return new ArrayList<>();
   }
 
   @Override
   public void updateGroup(GroupEntry groupEntry) throws IOException {
-    groupFileManager.deleteEntry(groupEntry.getName());
-    groupFileManager.addEntry(groupEntry.toString());
+    if (groupFileManager != null) {
+      groupFileManager.deleteEntry(groupEntry.getName());
+      groupFileManager.addEntry(groupEntry.toString());
+    }
   }
 
   @Override
   public List<IdentityEntry> getEntries() {
-    return passwdFileManager.getEntries();
+    if (passwdFileManager != null) {
+      return passwdFileManager.getEntries();
+    }
+    return new ArrayList<>();
   }
 
   @Override
@@ -120,14 +131,14 @@ public class ApacheBasicAuth implements IdentityLookup {
   }
 
   @Override
-  public boolean createUser(String username, String password, PasswordHandler handler)
+  public boolean createUser(String username, char[] password, PasswordHandler handler)
       throws IOException, GeneralSecurityException {
     String salt = PasswordGenerator.generateSalt(16);
-    byte[] hash =
-        handler.transformPassword(
-            password.getBytes(StandardCharsets.UTF_8), salt.getBytes(StandardCharsets.UTF_8), 12);
+    char[] hash =
+        handler.transformPassword(password, salt.getBytes(StandardCharsets.UTF_8), 12);
     if (passwdFileManager != null) {
-      passwdFileManager.addEntry(username, new String(hash));
+      passwdFileManager.addEntry(username, hash);
+      return true;
     }
     return false;
   }

--- a/src/main/java/io/mapsmessaging/security/identity/impl/apache/ApacheBasicAuth.java
+++ b/src/main/java/io/mapsmessaging/security/identity/impl/apache/ApacheBasicAuth.java
@@ -20,6 +20,7 @@ import io.mapsmessaging.configuration.ConfigurationProperties;
 import io.mapsmessaging.security.identity.*;
 import io.mapsmessaging.security.identity.impl.base.FileBaseGroups;
 import io.mapsmessaging.security.identity.impl.base.FileBaseIdentities;
+import io.mapsmessaging.security.passwords.PasswordBuffer;
 import io.mapsmessaging.security.passwords.PasswordHandler;
 import java.io.File;
 import java.io.IOException;
@@ -59,7 +60,7 @@ public class ApacheBasicAuth implements IdentityLookup {
   }
 
   @Override
-  public char[] getPasswordHash(String username) throws IOException, GeneralSecurityException {
+  public PasswordBuffer getPasswordHash(String username) throws IOException, GeneralSecurityException {
     if (passwdFileManager == null) {
       throw new NoSuchUserFoundException(username);
     }
@@ -168,5 +169,10 @@ public class ApacheBasicAuth implements IdentityLookup {
       return true;
     }
     return false;
+  }
+
+  @Override
+  public boolean canManage(){
+    return true;
   }
 }

--- a/src/main/java/io/mapsmessaging/security/identity/impl/apache/HtPasswdEntry.java
+++ b/src/main/java/io/mapsmessaging/security/identity/impl/apache/HtPasswdEntry.java
@@ -17,13 +17,14 @@
 package io.mapsmessaging.security.identity.impl.apache;
 
 import io.mapsmessaging.security.identity.IdentityEntry;
+import io.mapsmessaging.security.passwords.PasswordBuffer;
 import io.mapsmessaging.security.passwords.PasswordHandlerFactory;
 
 public class HtPasswdEntry extends IdentityEntry {
 
   public HtPasswdEntry(String username, char[] password) {
     this.username = username;
-    this.password = password;
+    this.password = new PasswordBuffer(password);
     passwordHasher = PasswordHandlerFactory.getInstance().parse(password);
   }
 
@@ -31,8 +32,8 @@ public class HtPasswdEntry extends IdentityEntry {
     int usernamePos = line.indexOf(":");
     username = line.substring(0, usernamePos);
     line = line.substring(usernamePos + 1);
-    password = line.toCharArray();
-    passwordHasher = PasswordHandlerFactory.getInstance().parse(password);
+    password = new PasswordBuffer(line.toCharArray());
+    passwordHasher = PasswordHandlerFactory.getInstance().parse(password.getHash());
   }
 
 }

--- a/src/main/java/io/mapsmessaging/security/identity/impl/apache/HtPasswdEntry.java
+++ b/src/main/java/io/mapsmessaging/security/identity/impl/apache/HtPasswdEntry.java
@@ -21,7 +21,7 @@ import io.mapsmessaging.security.passwords.PasswordHandlerFactory;
 
 public class HtPasswdEntry extends IdentityEntry {
 
-  public HtPasswdEntry(String username, String password) {
+  public HtPasswdEntry(String username, char[] password) {
     this.username = username;
     this.password = password;
     passwordHasher = PasswordHandlerFactory.getInstance().parse(password);
@@ -31,7 +31,7 @@ public class HtPasswdEntry extends IdentityEntry {
     int usernamePos = line.indexOf(":");
     username = line.substring(0, usernamePos);
     line = line.substring(usernamePos + 1);
-    password = line;
+    password = line.toCharArray();
     passwordHasher = PasswordHandlerFactory.getInstance().parse(password);
   }
 

--- a/src/main/java/io/mapsmessaging/security/identity/impl/apache/HtPasswdFileManager.java
+++ b/src/main/java/io/mapsmessaging/security/identity/impl/apache/HtPasswdFileManager.java
@@ -32,7 +32,7 @@ public class HtPasswdFileManager extends FileBaseIdentities {
   }
 
   @Override
-  protected IdentityEntry create(String username, String hash) {
+  protected IdentityEntry create(String username, char[] hash) {
     return new HtPasswdEntry(username, hash);
   }
 

--- a/src/main/java/io/mapsmessaging/security/identity/impl/auth0/Auth0Auth.java
+++ b/src/main/java/io/mapsmessaging/security/identity/impl/auth0/Auth0Auth.java
@@ -16,6 +16,9 @@
 
 package io.mapsmessaging.security.identity.impl.auth0;
 
+import static io.mapsmessaging.security.logging.AuthLogMessages.AUTH0_FAILURE;
+import static io.mapsmessaging.security.logging.AuthLogMessages.AUTH0_REQUEST_FAILURE;
+
 import com.auth0.client.auth.AuthAPI;
 import com.auth0.client.mgmt.ManagementAPI;
 import com.auth0.exception.Auth0Exception;
@@ -31,13 +34,10 @@ import io.mapsmessaging.security.identity.IdentityEntry;
 import io.mapsmessaging.security.identity.IdentityLookup;
 import io.mapsmessaging.security.identity.NoSuchUserFoundException;
 import io.mapsmessaging.security.identity.impl.external.CachingIdentityLookup;
-import lombok.Getter;
-
+import io.mapsmessaging.security.passwords.PasswordBuffer;
 import java.util.ArrayList;
 import java.util.List;
-
-import static io.mapsmessaging.security.logging.AuthLogMessages.AUTH0_FAILURE;
-import static io.mapsmessaging.security.logging.AuthLogMessages.AUTH0_REQUEST_FAILURE;
+import lombok.Getter;
 
 public class Auth0Auth extends CachingIdentityLookup<Auth0IdentityEntry> {
 
@@ -69,7 +69,7 @@ public class Auth0Auth extends CachingIdentityLookup<Auth0IdentityEntry> {
     auth0Domain = config.getProperty("domain");
     clientId = config.getProperty("clientId");
     clientSecret = config.getProperty("clientSecret");
-    String cacheTimeString = (String) config.getProperty("cacheTime");
+    String cacheTimeString = config.getProperty("cacheTime");
     if (cacheTimeString != null && !cacheTimeString.trim().isEmpty()) {
       cacheTime = Long.parseLong(cacheTimeString.trim());
     }
@@ -103,8 +103,8 @@ public class Auth0Auth extends CachingIdentityLookup<Auth0IdentityEntry> {
   }
 
   @Override
-  public char[] getPasswordHash(String username) throws NoSuchUserFoundException {
-    return new char[0];
+  public PasswordBuffer getPasswordHash(String username) throws NoSuchUserFoundException {
+    return new PasswordBuffer(new char[0]);
   }
 
   @Override

--- a/src/main/java/io/mapsmessaging/security/identity/impl/auth0/Auth0IdentityEntry.java
+++ b/src/main/java/io/mapsmessaging/security/identity/impl/auth0/Auth0IdentityEntry.java
@@ -21,6 +21,7 @@ import static io.mapsmessaging.security.logging.AuthLogMessages.AUTH0_PASSWORD_F
 import io.mapsmessaging.logging.Logger;
 import io.mapsmessaging.logging.LoggerFactory;
 import io.mapsmessaging.security.identity.impl.external.JwtIdentityEntry;
+import io.mapsmessaging.security.passwords.PasswordBuffer;
 import java.io.IOException;
 import java.security.GeneralSecurityException;
 
@@ -35,7 +36,7 @@ public class Auth0IdentityEntry extends JwtIdentityEntry {
   }
 
   @Override
-  public char[] getPassword() {
+  public PasswordBuffer getPassword() {
     try {
       return passwordHasher.getPassword();
     } catch (GeneralSecurityException | IOException e) {

--- a/src/main/java/io/mapsmessaging/security/identity/impl/auth0/Auth0IdentityEntry.java
+++ b/src/main/java/io/mapsmessaging/security/identity/impl/auth0/Auth0IdentityEntry.java
@@ -35,9 +35,9 @@ public class Auth0IdentityEntry extends JwtIdentityEntry {
   }
 
   @Override
-  public String getPassword() {
+  public char[] getPassword() {
     try {
-      return new String(passwordHasher.getPassword());
+      return passwordHasher.getPassword();
     } catch (GeneralSecurityException | IOException e) {
       logger.log(AUTH0_PASSWORD_FAILURE, username, e);
       return null;

--- a/src/main/java/io/mapsmessaging/security/identity/impl/auth0/Auth0PasswordHasher.java
+++ b/src/main/java/io/mapsmessaging/security/identity/impl/auth0/Auth0PasswordHasher.java
@@ -58,9 +58,9 @@ public class Auth0PasswordHasher extends JwtPasswordHasher implements TokenProvi
   }
 
   @Override
-  public byte[] transformPassword(byte[] password, byte[] salt, int cost) {
+  public char[] transformPassword(char[] password, byte[] salt, int cost) {
     if (auth == null) {
-      return new byte[0];
+      return new char[0];
     }
     String passwordString = new String(password);
     if (isJwt(passwordString)) {
@@ -75,7 +75,7 @@ public class Auth0PasswordHasher extends JwtPasswordHasher implements TokenProvi
       } catch (JwkException e) {
         logger.log(AUTH0_JWT_FAILURE, e);
       }
-      return new byte[0];
+      return new char[0];
     }
 
     try {
@@ -95,11 +95,11 @@ public class Auth0PasswordHasher extends JwtPasswordHasher implements TokenProvi
         return computedPassword;
       }
     } catch (Auth0Exception | JwkException e) {
-      computedPassword = new byte[12];
-      Arrays.fill(computedPassword, (byte) 0xff);
+      computedPassword = new char[12];
+      Arrays.fill(computedPassword, (char) 0xff);
       logger.log(AUTH0_JWT_FAILURE, e);
     }
-    return new byte[0];
+    return new char[0];
   }
 
   private void success() {

--- a/src/main/java/io/mapsmessaging/security/identity/impl/base/FileBaseIdentities.java
+++ b/src/main/java/io/mapsmessaging/security/identity/impl/base/FileBaseIdentities.java
@@ -22,6 +22,7 @@ import io.mapsmessaging.logging.Logger;
 import io.mapsmessaging.logging.LoggerFactory;
 import io.mapsmessaging.security.identity.IdentityEntry;
 import io.mapsmessaging.security.identity.NoSuchUserFoundException;
+import io.mapsmessaging.security.passwords.PasswordBuffer;
 import java.io.IOException;
 import java.security.GeneralSecurityException;
 import java.util.ArrayList;
@@ -43,7 +44,7 @@ public abstract class FileBaseIdentities extends FileLoader {
     return usernamePasswordMap.get(username);
   }
 
-  public char[] getPasswordHash(String username) throws IOException, GeneralSecurityException {
+  public PasswordBuffer getPasswordHash(String username) throws IOException, GeneralSecurityException {
     IdentityEntry identityEntry = usernamePasswordMap.get(username);
     if (identityEntry == null) {
       logger.log(NO_SUCH_USER_FOUND, username);

--- a/src/main/java/io/mapsmessaging/security/identity/impl/base/FileBaseIdentities.java
+++ b/src/main/java/io/mapsmessaging/security/identity/impl/base/FileBaseIdentities.java
@@ -49,7 +49,7 @@ public abstract class FileBaseIdentities extends FileLoader {
       logger.log(NO_SUCH_USER_FOUND, username);
       throw new NoSuchUserFoundException("User: " + username + " not found");
     }
-    return identityEntry.getPassword().toCharArray();
+    return identityEntry.getPassword();
   }
 
   public List<IdentityEntry> getEntries() {
@@ -58,13 +58,14 @@ public abstract class FileBaseIdentities extends FileLoader {
 
   protected abstract IdentityEntry load(String line);
 
-  protected abstract IdentityEntry create(String username, String hash);
+  protected abstract IdentityEntry create(String username, char[] hash);
+
   public void parse(String line) {
     IdentityEntry identityEntry = load(line);
     usernamePasswordMap.put(identityEntry.getUsername(), identityEntry);
   }
 
-  public void addEntry(String username, String passwordHash) throws IOException {
+  public void addEntry(String username, char[] passwordHash) throws IOException {
     IdentityEntry identityEntry = create(username, passwordHash);
     usernamePasswordMap.put(username, identityEntry);
     add(identityEntry.toString());

--- a/src/main/java/io/mapsmessaging/security/identity/impl/cognito/CognitoAuth.java
+++ b/src/main/java/io/mapsmessaging/security/identity/impl/cognito/CognitoAuth.java
@@ -23,14 +23,13 @@ import io.mapsmessaging.security.identity.IdentityLookup;
 import io.mapsmessaging.security.identity.NoSuchUserFoundException;
 import io.mapsmessaging.security.identity.impl.external.CachingIdentityLookup;
 import io.mapsmessaging.security.passwords.PasswordHandler;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.Getter;
 import software.amazon.awssdk.auth.credentials.AwsCredentials;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.cognitoidentityprovider.CognitoIdentityProviderClient;
 import software.amazon.awssdk.services.cognitoidentityprovider.model.*;
-
-import java.util.ArrayList;
-import java.util.List;
 
 @Getter
 public class CognitoAuth extends CachingIdentityLookup<CognitoIdentityEntry> {
@@ -54,15 +53,15 @@ public class CognitoAuth extends CachingIdentityLookup<CognitoIdentityEntry> {
   }
 
   public CognitoAuth(ConfigurationProperties config) {
-    userPoolId = (String) config.getProperty("userPoolId");
-    appClientId = (String) config.getProperty("appClientId");
-    appClientSecret = (String) config.getProperty("appClientSecret");
+    userPoolId = config.getProperty("userPoolId");
+    appClientId = config.getProperty("appClientId");
+    appClientSecret = config.getProperty("appClientSecret");
 
-    regionName = (String) config.getProperty("region");
-    String accesskeyId = (String) config.getProperty("accessKeyId");
-    String secretAccessKey = (String) config.getProperty("secretAccessKey");
+    regionName = config.getProperty("region");
+    String accesskeyId = config.getProperty("accessKeyId");
+    String secretAccessKey = config.getProperty("secretAccessKey");
 
-    String cacheTimeString = (String) config.getProperty("cacheTime");
+    String cacheTimeString = config.getProperty("cacheTime");
     if(cacheTimeString != null && !cacheTimeString.trim().isEmpty()){
       cacheTime = Long.parseLong(cacheTimeString.trim());
     }
@@ -186,7 +185,7 @@ public class CognitoAuth extends CachingIdentityLookup<CognitoIdentityEntry> {
   }
 
   @Override
-  public boolean createUser(String username, String passwordHash, PasswordHandler passwordHasher) {
+  public boolean createUser(String username, char[] passwordHash, PasswordHandler passwordHasher) {
     List<AttributeType> userAttributes = new ArrayList<>();
     if (username.contains("@")) {
       userAttributes.add(AttributeType.builder().name("email_verified").value("true").build());

--- a/src/main/java/io/mapsmessaging/security/identity/impl/cognito/CognitoAuth.java
+++ b/src/main/java/io/mapsmessaging/security/identity/impl/cognito/CognitoAuth.java
@@ -22,6 +22,7 @@ import io.mapsmessaging.security.identity.IdentityEntry;
 import io.mapsmessaging.security.identity.IdentityLookup;
 import io.mapsmessaging.security.identity.NoSuchUserFoundException;
 import io.mapsmessaging.security.identity.impl.external.CachingIdentityLookup;
+import io.mapsmessaging.security.passwords.PasswordBuffer;
 import io.mapsmessaging.security.passwords.PasswordHandler;
 import java.util.ArrayList;
 import java.util.List;
@@ -93,8 +94,8 @@ public class CognitoAuth extends CachingIdentityLookup<CognitoIdentityEntry> {
   }
 
   @Override
-  public char[] getPasswordHash(String username) throws NoSuchUserFoundException {
-    return new char[0];
+  public PasswordBuffer getPasswordHash(String username) throws NoSuchUserFoundException {
+    return new PasswordBuffer(new char[0]);
   }
 
   @Override

--- a/src/main/java/io/mapsmessaging/security/identity/impl/cognito/CognitoIdentityEntry.java
+++ b/src/main/java/io/mapsmessaging/security/identity/impl/cognito/CognitoIdentityEntry.java
@@ -17,6 +17,7 @@
 package io.mapsmessaging.security.identity.impl.cognito;
 
 import io.mapsmessaging.security.identity.impl.external.JwtIdentityEntry;
+import io.mapsmessaging.security.passwords.PasswordBuffer;
 import java.io.IOException;
 import java.security.GeneralSecurityException;
 import lombok.Getter;
@@ -38,7 +39,7 @@ public class CognitoIdentityEntry extends JwtIdentityEntry {
   }
 
   @Override
-  public char[] getPassword() throws GeneralSecurityException, IOException {
+  public PasswordBuffer getPassword() throws GeneralSecurityException, IOException {
     return passwordHasher.getPassword();
   }
 }

--- a/src/main/java/io/mapsmessaging/security/identity/impl/cognito/CognitoIdentityEntry.java
+++ b/src/main/java/io/mapsmessaging/security/identity/impl/cognito/CognitoIdentityEntry.java
@@ -38,7 +38,7 @@ public class CognitoIdentityEntry extends JwtIdentityEntry {
   }
 
   @Override
-  public String getPassword() throws GeneralSecurityException, IOException {
-    return new String(passwordHasher.getPassword());
+  public char[] getPassword() throws GeneralSecurityException, IOException {
+    return passwordHasher.getPassword();
   }
 }

--- a/src/main/java/io/mapsmessaging/security/identity/impl/cognito/CognitoPasswordHasher.java
+++ b/src/main/java/io/mapsmessaging/security/identity/impl/cognito/CognitoPasswordHasher.java
@@ -24,9 +24,9 @@ import io.mapsmessaging.security.identity.impl.external.JwtPasswordHasher;
 import io.mapsmessaging.security.identity.impl.external.JwtValidator;
 import io.mapsmessaging.security.identity.impl.external.TokenProvider;
 import io.mapsmessaging.security.jaas.aws.AwsAuthHelper;
+import io.mapsmessaging.security.passwords.PasswordBuffer;
 import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
-import java.util.Arrays;
 import java.util.Map;
 import software.amazon.awssdk.services.cognitoidentityprovider.model.AdminInitiateAuthRequest;
 import software.amazon.awssdk.services.cognitoidentityprovider.model.AdminInitiateAuthResponse;
@@ -38,8 +38,7 @@ public class CognitoPasswordHasher extends JwtPasswordHasher implements TokenPro
   private final String username;
   private final CognitoIdentityEntry identityEntry;
 
-  public CognitoPasswordHasher(
-      String username, CognitoAuth cognitoAuth, CognitoIdentityEntry identityEntry) {
+  public CognitoPasswordHasher(String username, CognitoAuth cognitoAuth, CognitoIdentityEntry identityEntry) {
     this.cognitoAuth = cognitoAuth;
     this.username = username;
     this.identityEntry = identityEntry;
@@ -54,9 +53,9 @@ public class CognitoPasswordHasher extends JwtPasswordHasher implements TokenPro
       if (isJwt(passwordString)) {
         JwtValidator validator = new JwtValidator(this);
         jwt = validator.validateJwt(username, passwordString);
-        computedPassword = password;
+        computedPassword = new PasswordBuffer(password);
         success();
-        return password;
+        return computedPassword.getHash();
       }
       // Login based on user/password
       String secretHash = generateSecretHash(username);
@@ -79,18 +78,19 @@ public class CognitoPasswordHasher extends JwtPasswordHasher implements TokenPro
       if (authResult != null) {
         JwtValidator validator = new JwtValidator(this);
         jwt = validator.validateJwt(username, authResult.idToken());
-        computedPassword = password;
+        computedPassword = new PasswordBuffer(password);
         success();
-        return password;
+        return computedPassword.getHash();
       }
     } catch (Exception ex) {
       // This is an invalid user, lets not log entries since DDOS lets just fail it
     }
     // If the above code executes without throwing an exception,
     // the JWT token is valid for the given user
-    computedPassword = new char[10];
-    Arrays.fill(computedPassword, (char) 0xff);
-    return new char[0];
+    if(computedPassword != null){
+      computedPassword.clear();
+    }
+    return "Invalid username / password combination.".toCharArray();
   }
 
 

--- a/src/main/java/io/mapsmessaging/security/identity/impl/cognito/CognitoPasswordHasher.java
+++ b/src/main/java/io/mapsmessaging/security/identity/impl/cognito/CognitoPasswordHasher.java
@@ -46,7 +46,7 @@ public class CognitoPasswordHasher extends JwtPasswordHasher implements TokenPro
   }
 
   @Override
-  public byte[] transformPassword(byte[] password, byte[] salt, int cost) {
+  public char[] transformPassword(char[] password, byte[] salt, int cost) {
     try {
       String passwordString = new String(password);
 
@@ -88,9 +88,9 @@ public class CognitoPasswordHasher extends JwtPasswordHasher implements TokenPro
     }
     // If the above code executes without throwing an exception,
     // the JWT token is valid for the given user
-    computedPassword = new byte[10];
-    Arrays.fill(computedPassword, (byte) 0xff);
-    return new byte[0];
+    computedPassword = new char[10];
+    Arrays.fill(computedPassword, (char) 0xff);
+    return new char[0];
   }
 
 

--- a/src/main/java/io/mapsmessaging/security/identity/impl/encrypted/EncryptedPasswordEntry.java
+++ b/src/main/java/io/mapsmessaging/security/identity/impl/encrypted/EncryptedPasswordEntry.java
@@ -17,6 +17,7 @@
 package io.mapsmessaging.security.identity.impl.encrypted;
 
 import io.mapsmessaging.security.identity.IdentityEntry;
+import io.mapsmessaging.security.passwords.PasswordBuffer;
 import io.mapsmessaging.security.passwords.PasswordHandler;
 import io.mapsmessaging.security.passwords.ciphers.EncryptedPasswordCipher;
 import java.io.IOException;
@@ -28,26 +29,26 @@ public class EncryptedPasswordEntry extends IdentityEntry {
     int usernamePos = line.indexOf(":");
     username = line.substring(0, usernamePos);
     line = line.substring(usernamePos + 1);
-    password = line.toCharArray();
-    passwordHasher = parser.create(password);
+    password = new PasswordBuffer(line.toCharArray());
+    passwordHasher = parser.create(password.getHash());
   }
 
   public EncryptedPasswordEntry(String username, char[] password, PasswordHandler parser) {
     this.username = username;
-    this.password = password;
+    this.password = new PasswordBuffer(password);
     this.passwordHasher = parser;
   }
 
   @Override
-  public char[] getPassword() throws GeneralSecurityException, IOException {
-    PasswordHandler parser1 = passwordHasher.create(password);
+  public PasswordBuffer getPassword() throws GeneralSecurityException, IOException {
+    PasswordHandler parser1 = passwordHasher.create(password.getHash());
     return parser1.getPassword();
   }
 
   @Override
   public PasswordHandler getPasswordHasher() {
     EncryptedPasswordCipher base = (EncryptedPasswordCipher) passwordHasher;
-    EncryptedPasswordCipher response = (EncryptedPasswordCipher) passwordHasher.create(password);
+    EncryptedPasswordCipher response = (EncryptedPasswordCipher) passwordHasher.create(password.getHash());
     response.setCertificateManager(base.getCertificateManager());
     return response;
   }

--- a/src/main/java/io/mapsmessaging/security/identity/impl/encrypted/EncryptedPasswordEntry.java
+++ b/src/main/java/io/mapsmessaging/security/identity/impl/encrypted/EncryptedPasswordEntry.java
@@ -28,20 +28,20 @@ public class EncryptedPasswordEntry extends IdentityEntry {
     int usernamePos = line.indexOf(":");
     username = line.substring(0, usernamePos);
     line = line.substring(usernamePos + 1);
-    password = line;
+    password = line.toCharArray();
     passwordHasher = parser.create(password);
   }
 
-  public EncryptedPasswordEntry(String username, String password, PasswordHandler parser) {
+  public EncryptedPasswordEntry(String username, char[] password, PasswordHandler parser) {
     this.username = username;
     this.password = password;
     this.passwordHasher = parser;
   }
 
   @Override
-  public String getPassword() throws GeneralSecurityException, IOException {
+  public char[] getPassword() throws GeneralSecurityException, IOException {
     PasswordHandler parser1 = passwordHasher.create(password);
-    return new String(parser1.getPassword());
+    return parser1.getPassword();
   }
 
   @Override

--- a/src/main/java/io/mapsmessaging/security/identity/impl/encrypted/EncryptedPasswordFileManager.java
+++ b/src/main/java/io/mapsmessaging/security/identity/impl/encrypted/EncryptedPasswordFileManager.java
@@ -22,9 +22,10 @@ import io.mapsmessaging.security.identity.impl.base.FileBaseIdentities;
 import io.mapsmessaging.security.passwords.ciphers.EncryptedPasswordCipher;
 import lombok.Getter;
 
+@Getter
 public class EncryptedPasswordFileManager extends FileBaseIdentities {
 
-  @Getter private final EncryptedPasswordCipher cipher;
+  private final EncryptedPasswordCipher cipher;
 
   public EncryptedPasswordFileManager(
       String filepath,
@@ -37,7 +38,7 @@ public class EncryptedPasswordFileManager extends FileBaseIdentities {
   }
 
   @Override
-  protected IdentityEntry create(String username, String hash) {
+  protected IdentityEntry create(String username, char[] hash) {
     return new EncryptedPasswordEntry(username, hash, cipher);
   }
 

--- a/src/main/java/io/mapsmessaging/security/identity/impl/external/CachingIdentityLookup.java
+++ b/src/main/java/io/mapsmessaging/security/identity/impl/external/CachingIdentityLookup.java
@@ -1,5 +1,5 @@
 /*
- * Copyright [ 2020 - 2023 ] [Matthew Buckton]
+ * Copyright [ 2020 - 2024 ] [Matthew Buckton]
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -64,4 +64,8 @@ public abstract class CachingIdentityLookup<T extends IdentityEntry> implements 
 
   protected abstract void loadUsers();
 
+  @Override
+  public boolean canManage(){
+    return true;
+  }
 }

--- a/src/main/java/io/mapsmessaging/security/identity/impl/external/JwtPasswordHasher.java
+++ b/src/main/java/io/mapsmessaging/security/identity/impl/external/JwtPasswordHasher.java
@@ -24,10 +24,10 @@ public abstract class JwtPasswordHasher implements PasswordHasher {
 
   @Getter
   protected DecodedJWT jwt;
-  protected byte[] computedPassword;
+  protected char[] computedPassword;
 
   @Override
-  public PasswordHasher create(String password) {
+  public PasswordHasher create(char[] password) {
     return null;
   }
 
@@ -47,7 +47,7 @@ public abstract class JwtPasswordHasher implements PasswordHasher {
   }
 
   @Override
-  public byte[] getPassword() {
+  public char[] getPassword() {
     return computedPassword;
   }
 

--- a/src/main/java/io/mapsmessaging/security/identity/impl/external/JwtPasswordHasher.java
+++ b/src/main/java/io/mapsmessaging/security/identity/impl/external/JwtPasswordHasher.java
@@ -17,14 +17,15 @@
 package io.mapsmessaging.security.identity.impl.external;
 
 import com.auth0.jwt.interfaces.DecodedJWT;
+import io.mapsmessaging.security.passwords.PasswordBuffer;
 import io.mapsmessaging.security.passwords.PasswordHasher;
 import lombok.Getter;
 
-public abstract class JwtPasswordHasher implements PasswordHasher {
+public abstract class JwtPasswordHasher extends PasswordHasher {
 
   @Getter
   protected DecodedJWT jwt;
-  protected char[] computedPassword;
+  protected PasswordBuffer computedPassword;
 
   @Override
   public PasswordHasher create(char[] password) {
@@ -47,12 +48,15 @@ public abstract class JwtPasswordHasher implements PasswordHasher {
   }
 
   @Override
-  public char[] getPassword() {
+  public PasswordBuffer getPassword() {
     return computedPassword;
   }
 
   @Override
   public char[] getFullPasswordHash() {
-    return new String(computedPassword).toCharArray();
+    if(computedPassword == null){
+      return new char[0];
+    }
+    return computedPassword.getHash();
   }
 }

--- a/src/main/java/io/mapsmessaging/security/identity/impl/ldap/LdapAuth.java
+++ b/src/main/java/io/mapsmessaging/security/identity/impl/ldap/LdapAuth.java
@@ -21,6 +21,7 @@ import io.mapsmessaging.security.identity.GroupEntry;
 import io.mapsmessaging.security.identity.IdentityEntry;
 import io.mapsmessaging.security.identity.IdentityLookup;
 import io.mapsmessaging.security.identity.NoSuchUserFoundException;
+import io.mapsmessaging.security.passwords.PasswordBuffer;
 import java.util.List;
 import javax.naming.Context;
 
@@ -51,7 +52,7 @@ public class LdapAuth implements IdentityLookup {
   }
 
   @Override
-  public char[] getPasswordHash(String username) throws NoSuchUserFoundException {
+  public PasswordBuffer getPasswordHash(String username) throws NoSuchUserFoundException {
     return ldapUserManager.getPasswordHash(username);
   }
 

--- a/src/main/java/io/mapsmessaging/security/identity/impl/ldap/LdapUser.java
+++ b/src/main/java/io/mapsmessaging/security/identity/impl/ldap/LdapUser.java
@@ -19,17 +19,17 @@ package io.mapsmessaging.security.identity.impl.ldap;
 import io.mapsmessaging.security.identity.IdentityEntry;
 import io.mapsmessaging.security.identity.principals.FullNamePrincipal;
 import io.mapsmessaging.security.identity.principals.HomeDirectoryPrincipal;
+import io.mapsmessaging.security.passwords.PasswordBuffer;
 import io.mapsmessaging.security.passwords.PasswordHandlerFactory;
-import lombok.Getter;
-
-import javax.naming.NamingEnumeration;
-import javax.naming.NamingException;
-import javax.naming.directory.Attribute;
-import javax.naming.directory.Attributes;
 import java.security.Principal;
 import java.util.Enumeration;
 import java.util.Map;
 import java.util.Set;
+import javax.naming.NamingEnumeration;
+import javax.naming.NamingException;
+import javax.naming.directory.Attribute;
+import javax.naming.directory.Attributes;
+import lombok.Getter;
 
 public class LdapUser extends IdentityEntry {
 
@@ -42,7 +42,7 @@ public class LdapUser extends IdentityEntry {
 
   public LdapUser(String username, char[] password, Attributes attrs) {
     super.username = username;
-    super.password = password;
+    super.password = new PasswordBuffer(password);
     super.passwordHasher = PasswordHandlerFactory.getInstance().parse(password);
     this.attrs = attrs;
     NamingEnumeration<? extends Attribute> namingEnum = attrs.getAll();

--- a/src/main/java/io/mapsmessaging/security/identity/impl/ldap/LdapUser.java
+++ b/src/main/java/io/mapsmessaging/security/identity/impl/ldap/LdapUser.java
@@ -20,14 +20,16 @@ import io.mapsmessaging.security.identity.IdentityEntry;
 import io.mapsmessaging.security.identity.principals.FullNamePrincipal;
 import io.mapsmessaging.security.identity.principals.HomeDirectoryPrincipal;
 import io.mapsmessaging.security.passwords.PasswordHandlerFactory;
-import java.security.Principal;
-import java.util.Enumeration;
-import java.util.Set;
+import lombok.Getter;
+
 import javax.naming.NamingEnumeration;
 import javax.naming.NamingException;
 import javax.naming.directory.Attribute;
 import javax.naming.directory.Attributes;
-import lombok.Getter;
+import java.security.Principal;
+import java.util.Enumeration;
+import java.util.Map;
+import java.util.Set;
 
 public class LdapUser extends IdentityEntry {
 
@@ -79,6 +81,15 @@ public class LdapUser extends IdentityEntry {
     return principals;
   }
 
+  public void setAttributeMap(Map<String, String> attributeMap) {
+    attributeMap.put("homeDirectory", homeDirectory);
+    attributeMap.put("description", description);
+    NamingEnumeration<? extends Attribute> enumeration = attrs.getAll();
+    while (enumeration.hasMoreElements()) {
+      Attribute attribute = enumeration.nextElement();
+      attributeMap.put(attribute.getID(), attribute.toString());
+    }
+  }
 
   static class LdapPrincipal implements Principal {
     private final String name;

--- a/src/main/java/io/mapsmessaging/security/identity/impl/ldap/LdapUser.java
+++ b/src/main/java/io/mapsmessaging/security/identity/impl/ldap/LdapUser.java
@@ -40,8 +40,8 @@ public class LdapUser extends IdentityEntry {
 
   public LdapUser(String username, char[] password, Attributes attrs) {
     super.username = username;
-    super.password = new String(password);
-    super.passwordHasher = PasswordHandlerFactory.getInstance().parse(new String(password));
+    super.password = password;
+    super.passwordHasher = PasswordHandlerFactory.getInstance().parse(password);
     this.attrs = attrs;
     NamingEnumeration<? extends Attribute> namingEnum = attrs.getAll();
     while (namingEnum.hasMoreElements()) {

--- a/src/main/java/io/mapsmessaging/security/identity/impl/ldap/LdapUserManager.java
+++ b/src/main/java/io/mapsmessaging/security/identity/impl/ldap/LdapUserManager.java
@@ -23,6 +23,7 @@ import io.mapsmessaging.security.identity.GroupEntry;
 import io.mapsmessaging.security.identity.IdentityEntry;
 import io.mapsmessaging.security.identity.NoSuchUserFoundException;
 import io.mapsmessaging.security.logging.AuthLogMessages;
+import io.mapsmessaging.security.util.ArrayHelper;
 import java.util.*;
 import java.util.Map.Entry;
 import javax.naming.NamingEnumeration;
@@ -30,6 +31,8 @@ import javax.naming.NamingException;
 import javax.naming.directory.*;
 
 public class LdapUserManager {
+
+  private static final char[] CRYPT_ARRAY = "{crypt}".toCharArray();
 
   private final Logger logger = LoggerFactory.getLogger(LdapUserManager.class);
   private final String passwordName;
@@ -58,6 +61,45 @@ public class LdapUserManager {
     groupMap = new LinkedHashMap<>();
     searchBase = config.getProperty("searchBase");
     groupSearchBase = config.getProperty("groupSearchBase");
+    load();
+  }
+
+
+  private void load(){
+    SearchControls searchControls = new SearchControls();
+    String[] returnedAtts = {"cn" };
+    searchControls.setReturningAttributes(returnedAtts);
+    searchControls.setSearchScope(SearchControls.SUBTREE_SCOPE);
+    String searchFilter =  "(cn=*)";
+    DirContext directoryContext = null;
+    List<String> usernames = new ArrayList<>();
+    try {
+      directoryContext = new InitialDirContext(new Hashtable<>(map));
+      loadGroups(null, directoryContext, "*");
+
+      NamingEnumeration<SearchResult> results = directoryContext.search(searchBase, searchFilter, searchControls);
+      while(results.hasMore()){
+        SearchResult result = results.nextElement();
+        Attributes attrs = result.getAttributes();
+        Attribute user = attrs.get("cn");
+        String userString = (String) user.get();
+        usernames.add(userString);
+      }
+    } catch (NamingException e) {
+      logger.log(AuthLogMessages.LDAP_LOAD_FAILURE, e);
+    } finally {
+      if (directoryContext != null) {
+        try {
+          directoryContext.close();
+        } catch (NamingException e) {
+          // we can ignore the close exception here
+        }
+      }
+    }
+    for(String username:usernames){
+      findUser(username);
+    }
+
   }
 
   public IdentityEntry findEntry(String username) {
@@ -96,11 +138,8 @@ public class LdapUserManager {
         if (password != null) {
           Object v = password.get();
           if (v instanceof byte[]) {
-            String s = new String((byte[]) v);
-            if (s.toLowerCase().startsWith("{crypt}")) {
-              s = s.substring("{crypt}".length());
-            }
-            LdapUser ldapUser = new LdapUser(userString, s.toCharArray(), attrs);
+            char[] passwordArray = checkOrAppend(ArrayHelper.byteArrayToCharArray((byte[])v));
+            LdapUser ldapUser = new LdapUser(userString, passwordArray, attrs);
             loadGroups(ldapUser, directoryContext, username);
             userMap.put(ldapUser.getUsername(), ldapUser);
             return ldapUser;
@@ -121,6 +160,13 @@ public class LdapUserManager {
     return null;
   }
 
+  private char[] checkOrAppend(char[] password){
+    if (password.length > CRYPT_ARRAY.length && ArrayHelper.startsWithIgnoreCase(password, CRYPT_ARRAY)) {
+      return ArrayHelper.substring(password, CRYPT_ARRAY.length);
+    }
+    return password;
+  }
+
   private void loadGroups(LdapUser ldapUser, DirContext directoryContext, String userId) throws NamingException {
     String[] attributes = {"cn"};
     SearchControls groupSearchControls = new SearchControls();
@@ -138,23 +184,24 @@ public class LdapUserManager {
     }
   }
 
-
   private void processGroup(LdapUser ldapUser, Attribute groupName){
     try{
-    if (groupName != null) {
-      String name = groupName.get().toString();
-      LdapGroup groupEntry = groupMap.get(name);
-      if(groupEntry == null){
-        groupEntry = new LdapGroup(name);
-        groupMap.put(groupEntry.getName(), groupEntry);
+      if (groupName != null) {
+        String name = groupName.get().toString();
+        LdapGroup groupEntry = groupMap.get(name);
+        if(groupEntry == null){
+          groupEntry = new LdapGroup(name);
+          groupMap.put(groupEntry.getName(), groupEntry);
+        }
+        if (ldapUser != null) {
+          if (!groupEntry.isInGroup(ldapUser.getUsername())) {
+            groupEntry.addUser(ldapUser.getUsername());
+          }
+          if (!ldapUser.isInGroup(name)) {
+            ldapUser.addGroup(groupEntry);
+          }
+        }
       }
-        if (!groupEntry.isInGroup(ldapUser.getUsername())) {
-        groupEntry.addUser(ldapUser.getUsername());
-      }
-      if (!ldapUser.isInGroup(name)) {
-        ldapUser.addGroup(groupEntry);
-      }
-    }
     }
     catch(NamingException namingException){
       logger.log(AuthLogMessages.LDAP_LOAD_FAILURE, namingException);

--- a/src/main/java/io/mapsmessaging/security/identity/impl/ldap/LdapUserManager.java
+++ b/src/main/java/io/mapsmessaging/security/identity/impl/ldap/LdapUserManager.java
@@ -23,6 +23,7 @@ import io.mapsmessaging.security.identity.GroupEntry;
 import io.mapsmessaging.security.identity.IdentityEntry;
 import io.mapsmessaging.security.identity.NoSuchUserFoundException;
 import io.mapsmessaging.security.logging.AuthLogMessages;
+import io.mapsmessaging.security.passwords.PasswordBuffer;
 import io.mapsmessaging.security.util.ArrayHelper;
 import java.util.*;
 import java.util.Map.Entry;
@@ -110,10 +111,10 @@ public class LdapUserManager {
     return entry;
   }
 
-  public char[] getPasswordHash(String username) throws NoSuchUserFoundException {
+  public PasswordBuffer getPasswordHash(String username) throws NoSuchUserFoundException {
     IdentityEntry entry = findEntry(username);
     if (entry != null) {
-      return entry.getPasswordHasher().getFullPasswordHash();
+      return new PasswordBuffer(entry.getPasswordHasher().getFullPasswordHash());
     }
     throw new NoSuchUserFoundException("Password entry for " + username + " not found");
   }

--- a/src/main/java/io/mapsmessaging/security/identity/impl/unix/ShadowEntry.java
+++ b/src/main/java/io/mapsmessaging/security/identity/impl/unix/ShadowEntry.java
@@ -36,7 +36,7 @@ public class ShadowEntry extends IdentityEntry {
     username = line.substring(0, usernamePos);
     line = line.substring(usernamePos + 1);
     int endOfPassword = line.indexOf(":");
-    password = line.substring(0, endOfPassword);
+    password = line.substring(0, endOfPassword).toCharArray();
     passwordHasher = PasswordHandlerFactory.getInstance().parse(password);
   }
 

--- a/src/main/java/io/mapsmessaging/security/identity/impl/unix/ShadowEntry.java
+++ b/src/main/java/io/mapsmessaging/security/identity/impl/unix/ShadowEntry.java
@@ -19,13 +19,13 @@ package io.mapsmessaging.security.identity.impl.unix;
 import io.mapsmessaging.security.identity.IdentityEntry;
 import io.mapsmessaging.security.identity.principals.FullNamePrincipal;
 import io.mapsmessaging.security.identity.principals.HomeDirectoryPrincipal;
+import io.mapsmessaging.security.passwords.PasswordBuffer;
 import io.mapsmessaging.security.passwords.PasswordHandlerFactory;
-import lombok.Getter;
-import lombok.Setter;
-
 import java.security.Principal;
 import java.util.Map;
 import java.util.Set;
+import lombok.Getter;
+import lombok.Setter;
 
 public class ShadowEntry extends IdentityEntry {
 
@@ -38,8 +38,8 @@ public class ShadowEntry extends IdentityEntry {
     username = line.substring(0, usernamePos);
     line = line.substring(usernamePos + 1);
     int endOfPassword = line.indexOf(":");
-    password = line.substring(0, endOfPassword).toCharArray();
-    passwordHasher = PasswordHandlerFactory.getInstance().parse(password);
+    password = new PasswordBuffer(line.substring(0, endOfPassword).toCharArray());
+    passwordHasher = PasswordHandlerFactory.getInstance().parse(password.getHash());
   }
 
   @Override

--- a/src/main/java/io/mapsmessaging/security/identity/impl/unix/ShadowEntry.java
+++ b/src/main/java/io/mapsmessaging/security/identity/impl/unix/ShadowEntry.java
@@ -20,10 +20,12 @@ import io.mapsmessaging.security.identity.IdentityEntry;
 import io.mapsmessaging.security.identity.principals.FullNamePrincipal;
 import io.mapsmessaging.security.identity.principals.HomeDirectoryPrincipal;
 import io.mapsmessaging.security.passwords.PasswordHandlerFactory;
-import java.security.Principal;
-import java.util.Set;
 import lombok.Getter;
 import lombok.Setter;
+
+import java.security.Principal;
+import java.util.Map;
+import java.util.Set;
 
 public class ShadowEntry extends IdentityEntry {
 
@@ -50,5 +52,8 @@ public class ShadowEntry extends IdentityEntry {
     return principals;
   }
 
-
+  public void setAttributeMap(Map<String, String> attributeMap) {
+    attributeMap.put("homeDirectory", passwordEntry.getHomeDirectory());
+    attributeMap.put("description", passwordEntry.getDescription());
+  }
 }

--- a/src/main/java/io/mapsmessaging/security/identity/impl/unix/ShadowFileManager.java
+++ b/src/main/java/io/mapsmessaging/security/identity/impl/unix/ShadowFileManager.java
@@ -32,8 +32,8 @@ public class ShadowFileManager extends FileBaseIdentities {
   }
 
   @Override
-  protected IdentityEntry create(String username, String hash) {
-    return new ShadowEntry(hash);
+  protected IdentityEntry create(String username, char[] hash) {
+    return new ShadowEntry(new String(hash));
   }
 
 }

--- a/src/main/java/io/mapsmessaging/security/identity/impl/unix/UnixAuth.java
+++ b/src/main/java/io/mapsmessaging/security/identity/impl/unix/UnixAuth.java
@@ -21,7 +21,7 @@ import io.mapsmessaging.security.identity.GroupEntry;
 import io.mapsmessaging.security.identity.IdentityEntry;
 import io.mapsmessaging.security.identity.IdentityLookup;
 import io.mapsmessaging.security.identity.impl.base.FileBaseIdentities;
-
+import io.mapsmessaging.security.passwords.PasswordBuffer;
 import java.io.File;
 import java.io.IOException;
 import java.security.GeneralSecurityException;
@@ -60,7 +60,7 @@ public class UnixAuth implements IdentityLookup {
   }
 
   @Override
-  public char[] getPasswordHash(String username) throws IOException, GeneralSecurityException {
+  public PasswordBuffer getPasswordHash(String username) throws IOException, GeneralSecurityException {
     return passwordFileIdentities.getPasswordHash(username);
   }
 

--- a/src/main/java/io/mapsmessaging/security/jaas/IdentityLoginModule.java
+++ b/src/main/java/io/mapsmessaging/security/jaas/IdentityLoginModule.java
@@ -68,7 +68,7 @@ public class IdentityLoginModule extends BaseLoginModule {
     try {
       PasswordHandler passwordHasher = identityEntry.getPasswordHasher();
       if (passwordHasher == null) {
-        passwordHasher = PasswordHandlerFactory.getInstance().parse(identityEntry.getPassword());
+        passwordHasher = PasswordHandlerFactory.getInstance().parse(identityEntry.getPassword().getHash());
       }
       boolean result = passwordHasher.matches(password);
       if(password != null) Arrays.fill(password, (char) 0x0);

--- a/src/main/java/io/mapsmessaging/security/passwords/PasswordBuffer.java
+++ b/src/main/java/io/mapsmessaging/security/passwords/PasswordBuffer.java
@@ -24,15 +24,17 @@ public class PasswordBuffer {
 
   public PasswordBuffer(char[] hash) {
     byte[] buf = ArrayHelper.charArrayToByteArray(hash);
-    buffer = ByteBuffer.allocateDirect(buf.length);
-    buffer.put(buf);
-    buffer.flip();
+    ByteBuffer tmp = ByteBuffer.allocateDirect(buf.length);
+    tmp.put(buf);
+    tmp.flip();
+    buffer = tmp.asReadOnlyBuffer();
   }
 
   public PasswordBuffer(byte[] buf) {
-    buffer = ByteBuffer.allocateDirect(buf.length);
-    buffer.put(buf);
-    buffer.flip();
+    ByteBuffer tmp = ByteBuffer.allocateDirect(buf.length);
+    tmp.put(buf);
+    tmp.flip();
+    buffer = tmp.asReadOnlyBuffer();
   }
 
   public void clear(){

--- a/src/main/java/io/mapsmessaging/security/passwords/PasswordBuffer.java
+++ b/src/main/java/io/mapsmessaging/security/passwords/PasswordBuffer.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright [ 2020 - 2024 ] [Matthew Buckton]
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.mapsmessaging.security.passwords;
+
+import io.mapsmessaging.security.util.ArrayHelper;
+import java.nio.ByteBuffer;
+
+public class PasswordBuffer {
+  private final ByteBuffer buffer;
+
+  public PasswordBuffer(char[] hash) {
+    byte[] buf = ArrayHelper.charArrayToByteArray(hash);
+    ArrayHelper.clearCharArray(hash);
+    buffer = ByteBuffer.allocateDirect(buf.length);
+    buffer.put(buf);
+    buffer.flip();
+    ArrayHelper.clearByteArray(buf);
+  }
+  public void clear(){
+    byte[] buf = buffer.array();
+    ArrayHelper.clearByteArray(buf);
+    buffer.clear();
+    buffer.put(buf);
+  }
+
+  public byte[] getBytes(){
+    byte[] buf =new byte[buffer.remaining()];
+    buffer.get(buf);
+    buffer.flip();
+    return buf;
+  }
+
+  public char[] getHash() {
+    return ArrayHelper.byteArrayToCharArray(getBytes());
+  }
+}

--- a/src/main/java/io/mapsmessaging/security/passwords/PasswordBuffer.java
+++ b/src/main/java/io/mapsmessaging/security/passwords/PasswordBuffer.java
@@ -24,12 +24,17 @@ public class PasswordBuffer {
 
   public PasswordBuffer(char[] hash) {
     byte[] buf = ArrayHelper.charArrayToByteArray(hash);
-    ArrayHelper.clearCharArray(hash);
     buffer = ByteBuffer.allocateDirect(buf.length);
     buffer.put(buf);
     buffer.flip();
-    ArrayHelper.clearByteArray(buf);
   }
+
+  public PasswordBuffer(byte[] buf) {
+    buffer = ByteBuffer.allocateDirect(buf.length);
+    buffer.put(buf);
+    buffer.flip();
+  }
+
   public void clear(){
     byte[] buf = buffer.array();
     ArrayHelper.clearByteArray(buf);

--- a/src/main/java/io/mapsmessaging/security/passwords/PasswordCipher.java
+++ b/src/main/java/io/mapsmessaging/security/passwords/PasswordCipher.java
@@ -20,10 +20,10 @@ import java.io.IOException;
 import java.security.GeneralSecurityException;
 import java.util.Arrays;
 
-public interface PasswordCipher extends PasswordHandler {
+public abstract class PasswordCipher extends PasswordHandler {
 
   @Override
-  default boolean matches(char[] attemptedPassword) throws GeneralSecurityException, IOException {
-    return Arrays.equals(attemptedPassword, getPassword());
+  public boolean matches(char[] attemptedPassword) throws GeneralSecurityException, IOException {
+    return Arrays.equals(attemptedPassword, getPassword().getHash());
   }
 }

--- a/src/main/java/io/mapsmessaging/security/passwords/PasswordCipher.java
+++ b/src/main/java/io/mapsmessaging/security/passwords/PasswordCipher.java
@@ -1,11 +1,11 @@
 /*
  * Copyright [ 2020 - 2024 ] [Matthew Buckton]
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,7 +16,14 @@
 
 package io.mapsmessaging.security.passwords;
 
+import java.io.IOException;
+import java.security.GeneralSecurityException;
+import java.util.Arrays;
+
 public interface PasswordCipher extends PasswordHandler {
 
-
+  @Override
+  default boolean matches(char[] attemptedPassword) throws GeneralSecurityException, IOException {
+    return Arrays.equals(attemptedPassword, getPassword());
+  }
 }

--- a/src/main/java/io/mapsmessaging/security/passwords/PasswordHandler.java
+++ b/src/main/java/io/mapsmessaging/security/passwords/PasswordHandler.java
@@ -18,6 +18,7 @@ package io.mapsmessaging.security.passwords;
 
 import java.io.IOException;
 import java.security.GeneralSecurityException;
+import java.util.Arrays;
 
 public interface PasswordHandler {
 
@@ -35,6 +36,12 @@ public interface PasswordHandler {
   char[] getPassword() throws GeneralSecurityException, IOException;
 
   char[] getFullPasswordHash();
+
+  default boolean matches(char[] attemptedPassword) throws GeneralSecurityException, IOException {
+    char[] remoteHash = transformPassword(attemptedPassword, getSalt(), getCost());
+    char[] localHash = getFullPasswordHash();
+    return Arrays.equals(remoteHash, localHash);
+  }
 
   String getName();
 

--- a/src/main/java/io/mapsmessaging/security/passwords/PasswordHandler.java
+++ b/src/main/java/io/mapsmessaging/security/passwords/PasswordHandler.java
@@ -16,37 +16,39 @@
 
 package io.mapsmessaging.security.passwords;
 
+import io.mapsmessaging.security.util.ArrayHelper;
 import java.io.IOException;
 import java.security.GeneralSecurityException;
 import java.util.Arrays;
 
-public interface PasswordHandler {
+public abstract class PasswordHandler {
 
-  char[] transformPassword(char[] password, byte[] salt, int cost)
-      throws GeneralSecurityException, IOException;
-
-  PasswordHandler create(char[] password);
-
-  String getKey();
-
-  boolean hasSalt();
-
-  byte[] getSalt();
-
-  char[] getPassword() throws GeneralSecurityException, IOException;
-
-  char[] getFullPasswordHash();
-
-  default boolean matches(char[] attemptedPassword) throws GeneralSecurityException, IOException {
+  public boolean matches(char[] attemptedPassword) throws GeneralSecurityException, IOException {
     char[] remoteHash = transformPassword(attemptedPassword, getSalt(), getCost());
     char[] localHash = getFullPasswordHash();
-    return Arrays.equals(remoteHash, localHash);
+    boolean result = Arrays.equals(remoteHash, localHash);
+    ArrayHelper.clearCharArray(localHash);
+    return result;
   }
 
-  String getName();
-
-  default int getCost() {
+  public int getCost() {
     return 0;
   }
+
+  public abstract String getName();
+
+  public abstract char[] transformPassword(char[] password, byte[] salt, int cost) throws GeneralSecurityException, IOException;
+
+  public abstract PasswordHandler create(char[] password);
+
+  public abstract String getKey();
+
+  public abstract boolean hasSalt();
+
+  public abstract byte[] getSalt();
+
+  public abstract PasswordBuffer getPassword() throws GeneralSecurityException, IOException;
+
+  public abstract char[] getFullPasswordHash();
 
 }

--- a/src/main/java/io/mapsmessaging/security/passwords/PasswordHandler.java
+++ b/src/main/java/io/mapsmessaging/security/passwords/PasswordHandler.java
@@ -28,6 +28,7 @@ public abstract class PasswordHandler {
     char[] localHash = getFullPasswordHash();
     boolean result = Arrays.equals(remoteHash, localHash);
     ArrayHelper.clearCharArray(localHash);
+    ArrayHelper.clearCharArray(remoteHash);
     return result;
   }
 

--- a/src/main/java/io/mapsmessaging/security/passwords/PasswordHandler.java
+++ b/src/main/java/io/mapsmessaging/security/passwords/PasswordHandler.java
@@ -21,10 +21,10 @@ import java.security.GeneralSecurityException;
 
 public interface PasswordHandler {
 
-  byte[] transformPassword(byte[] password, byte[] salt, int cost)
+  char[] transformPassword(char[] password, byte[] salt, int cost)
       throws GeneralSecurityException, IOException;
 
-  PasswordHandler create(String password);
+  PasswordHandler create(char[] password);
 
   String getKey();
 
@@ -32,7 +32,7 @@ public interface PasswordHandler {
 
   byte[] getSalt();
 
-  byte[] getPassword() throws GeneralSecurityException, IOException;
+  char[] getPassword() throws GeneralSecurityException, IOException;
 
   char[] getFullPasswordHash();
 

--- a/src/main/java/io/mapsmessaging/security/passwords/PasswordHandlerFactory.java
+++ b/src/main/java/io/mapsmessaging/security/passwords/PasswordHandlerFactory.java
@@ -21,6 +21,7 @@ import static io.mapsmessaging.security.logging.AuthLogMessages.PASSWORD_PARSER_
 import io.mapsmessaging.logging.Logger;
 import io.mapsmessaging.logging.LoggerFactory;
 import io.mapsmessaging.security.passwords.hashes.plain.PlainPasswordHasher;
+import io.mapsmessaging.security.util.ArrayHelper;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.ServiceLoader;
@@ -64,29 +65,14 @@ public class PasswordHandlerFactory {
 
   public PasswordHandler parse(char[] password) {
     for (PasswordHandler handler : passwordHandlers) {
+      char[] key = handler.getKey().toCharArray();
       if (!handler.getName().equals("PLAIN")
-          && password.length >= handler.getKey().length()
-          && startWith(password, handler.getKey().toCharArray())) {
-        return handler.create(new String(password));
+          && password.length >= key.length
+          && ArrayHelper.startsWithIgnoreCase(password, key)) {
+        return handler.create(password);
       }
     }
-    return new PlainPasswordHasher(new String(password));
-  }
-
-  private boolean startWith(char[] longString, char[] start) {
-    if (start.length >= longString.length) {
-      return false;
-    }
-    for (int x = 0; x < start.length; x++) {
-      if (longString[x] != start[x]) {
-        return false;
-      }
-    }
-    return true;
-  }
-
-  public PasswordHandler parse(String password) {
-    return parse(password.toCharArray());
+    return new PlainPasswordHasher(password);
   }
 
 }

--- a/src/main/java/io/mapsmessaging/security/passwords/PasswordHasher.java
+++ b/src/main/java/io/mapsmessaging/security/passwords/PasswordHasher.java
@@ -1,11 +1,11 @@
 /*
  * Copyright [ 2020 - 2024 ] [Matthew Buckton]
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,6 +16,6 @@
 
 package io.mapsmessaging.security.passwords;
 
-public interface PasswordHasher extends PasswordHandler {
+public abstract class PasswordHasher extends PasswordHandler {
 
 }

--- a/src/main/java/io/mapsmessaging/security/passwords/ciphers/EncryptedPasswordCipher.java
+++ b/src/main/java/io/mapsmessaging/security/passwords/ciphers/EncryptedPasswordCipher.java
@@ -28,7 +28,7 @@ import java.util.Base64;
 import lombok.Getter;
 import lombok.Setter;
 
-public class EncryptedPasswordCipher implements PasswordCipher {
+public class EncryptedPasswordCipher extends PasswordCipher {
 
   private PasswordBuffer password;
 
@@ -112,7 +112,7 @@ public class EncryptedPasswordCipher implements PasswordCipher {
   }
 
   @Override
-  public char[] getPassword() throws GeneralSecurityException, IOException {
+  public PasswordBuffer getPassword() throws GeneralSecurityException, IOException {
     BufferCipher bufferCipher = new BufferCipher(certificateManager);
     byte[] decoded = Base64.getDecoder().decode(password.getBytes());
     byte[] decrypted = bufferCipher.decrypt(alias, decoded, privateKeyPassword.toCharArray());
@@ -129,7 +129,11 @@ public class EncryptedPasswordCipher implements PasswordCipher {
     for (int i = 0; i < xorPassword.length; i++) {
       originalPassword[i] = (byte) (xorPassword[i] ^ salt[i % salt.length]);
     }
-    return new String(originalPassword).toCharArray();
+    ArrayHelper.clearByteArray(salt);
+    ArrayHelper.clearByteArray(xorPassword);
+    ArrayHelper.clearByteArray(decoded);
+    ArrayHelper.clearByteArray(decrypted);
+    return new PasswordBuffer(originalPassword);
   }
 
   @Override

--- a/src/main/java/io/mapsmessaging/security/passwords/hashes/bcrypt/BCrypt2APasswordHasher.java
+++ b/src/main/java/io/mapsmessaging/security/passwords/hashes/bcrypt/BCrypt2APasswordHasher.java
@@ -1,11 +1,11 @@
 /*
  * Copyright [ 2020 - 2024 ] [Matthew Buckton]
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -25,11 +25,11 @@ public class BCrypt2APasswordHasher extends BCryptPasswordHasher {
     super(Version.VERSION_2A);
   }
 
-  public BCrypt2APasswordHasher(String password) {
+  public BCrypt2APasswordHasher(char[] password) {
     super(password, Version.VERSION_2A);
   }
 
-  public PasswordHasher create(String password) {
+  public PasswordHasher create(char[] password) {
     return new BCrypt2APasswordHasher(password);
   }
 

--- a/src/main/java/io/mapsmessaging/security/passwords/hashes/bcrypt/BCrypt2BPasswordHasher.java
+++ b/src/main/java/io/mapsmessaging/security/passwords/hashes/bcrypt/BCrypt2BPasswordHasher.java
@@ -1,11 +1,11 @@
 /*
  * Copyright [ 2020 - 2024 ] [Matthew Buckton]
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -25,11 +25,11 @@ public class BCrypt2BPasswordHasher extends BCryptPasswordHasher {
     super(Version.VERSION_2B);
   }
 
-  public BCrypt2BPasswordHasher(String password) {
+  public BCrypt2BPasswordHasher(char[] password) {
     super(password, Version.VERSION_2B);
   }
 
-  public PasswordHasher create(String password) {
+  public PasswordHasher create(char[] password) {
     return new BCrypt2BPasswordHasher(password);
   }
 

--- a/src/main/java/io/mapsmessaging/security/passwords/hashes/bcrypt/BCrypt2XPasswordHasher.java
+++ b/src/main/java/io/mapsmessaging/security/passwords/hashes/bcrypt/BCrypt2XPasswordHasher.java
@@ -1,11 +1,11 @@
 /*
  * Copyright [ 2020 - 2024 ] [Matthew Buckton]
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -25,11 +25,11 @@ public class BCrypt2XPasswordHasher extends BCryptPasswordHasher {
     super(Version.VERSION_2X);
   }
 
-  public BCrypt2XPasswordHasher(String password) {
+  public BCrypt2XPasswordHasher(char[] password) {
     super(password, Version.VERSION_2X);
   }
 
-  public PasswordHasher create(String password) {
+  public PasswordHasher create(char[] password) {
     return new BCrypt2XPasswordHasher(password);
   }
 

--- a/src/main/java/io/mapsmessaging/security/passwords/hashes/bcrypt/BCrypt2YPasswordHasher.java
+++ b/src/main/java/io/mapsmessaging/security/passwords/hashes/bcrypt/BCrypt2YPasswordHasher.java
@@ -1,11 +1,11 @@
 /*
  * Copyright [ 2020 - 2024 ] [Matthew Buckton]
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -25,11 +25,11 @@ public class BCrypt2YPasswordHasher extends BCryptPasswordHasher {
     super(Version.VERSION_2Y);
   }
 
-  public BCrypt2YPasswordHasher(String password) {
+  public BCrypt2YPasswordHasher(char[] password) {
     super(password, Version.VERSION_2Y);
   }
 
-  public PasswordHasher create(String password) {
+  public PasswordHasher create(char[] password) {
     return new BCrypt2YPasswordHasher(password);
   }
 

--- a/src/main/java/io/mapsmessaging/security/passwords/hashes/bcrypt/BCryptPasswordHasher.java
+++ b/src/main/java/io/mapsmessaging/security/passwords/hashes/bcrypt/BCryptPasswordHasher.java
@@ -20,47 +20,49 @@ import at.favre.lib.crypto.bcrypt.BCrypt;
 import at.favre.lib.crypto.bcrypt.BCrypt.Version;
 import at.favre.lib.crypto.bcrypt.Radix64Encoder;
 import io.mapsmessaging.security.passwords.PasswordHasher;
-import java.nio.charset.StandardCharsets;
+import io.mapsmessaging.security.util.ArrayHelper;
 
 public abstract class BCryptPasswordHasher implements PasswordHasher {
 
+  private static final int SALT_SIZE = 22;
   private static final int DEFAULT_COST = 12;
 
   private final Version version;
-  private final byte[] password;
+  private final char[] password;
   private final byte[] salt;
   private final int cost;
 
   protected BCryptPasswordHasher() {
-    password = new byte[0];
+    password = new char[0];
     salt = new byte[0];
     cost = DEFAULT_COST;
     version = null;
   }
 
   protected BCryptPasswordHasher(Version version) {
-    password = new byte[0];
+    password = new char[0];
     salt = new byte[0];
     cost = DEFAULT_COST;
     this.version = version;
   }
 
-  protected BCryptPasswordHasher(String password, Version version) {
+  protected BCryptPasswordHasher(char[] password, Version version) {
     this.version = version;
-    if (password.isEmpty()) {
+    if (password == null || password.length == 0) {
       salt = new byte[0];
-      this.password = new byte[0];
+      this.password = new char[0];
       cost = DEFAULT_COST;
     } else {
-      String t = password.substring(getKey().length());
-      int dollar = t.indexOf("$");
-      cost = Integer.parseInt(t.substring(0, dollar));
-      t = t.substring(dollar + 1);
-      String s = t.substring(0, 22);
-      String p = t.substring(22);
+      char[] t = ArrayHelper.substring(password, getKey().length());
+
+      int dollar = ArrayHelper.indexOf(t, '$');
+      cost = Integer.parseInt( new String(ArrayHelper.substring(t, 0, dollar)));
+      t = ArrayHelper.substring(t, dollar + 1);
+      char[] s = ArrayHelper.substring(t,0, SALT_SIZE);
+      char[] p = ArrayHelper.substring(t, SALT_SIZE);
       Radix64Encoder encoder = new Radix64Encoder.Default();
-      salt = encoder.decode(s.getBytes(StandardCharsets.UTF_8));
-      this.password = encoder.decode(p.getBytes(StandardCharsets.UTF_8));
+      salt = encoder.decode(ArrayHelper.charArrayToByteArray(s));
+      this.password = ArrayHelper.byteArrayToCharArray(encoder.decode(ArrayHelper.charArrayToByteArray(p)));
     }
   }
 
@@ -75,8 +77,8 @@ public abstract class BCryptPasswordHasher implements PasswordHasher {
   }
 
   @Override
-  public byte[] transformPassword(byte[] password, byte[] salt, int cost) {
-    return BCrypt.with(version).hash(cost, salt, password);
+  public char[] transformPassword(char[] password, byte[] salt, int cost) {
+    return ArrayHelper.byteArrayToCharArray(BCrypt.with(version).hash(cost, salt, ArrayHelper.charArrayToByteArray(password)));
   }
 
   @Override
@@ -85,14 +87,14 @@ public abstract class BCryptPasswordHasher implements PasswordHasher {
   }
 
   @Override
-  public byte[] getPassword() {
+  public char[] getPassword() {
     return password;
   }
 
   @Override
   public char[] getFullPasswordHash() {
     Radix64Encoder encoder = new Radix64Encoder.Default();
-    String t = new String(encoder.encode(salt)) + new String(encoder.encode(password));
+    String t = new String(encoder.encode(salt)) + new String(encoder.encode(ArrayHelper.charArrayToByteArray(password)));
     return (getKey() + cost + "$" + t).toCharArray();
   }
 

--- a/src/main/java/io/mapsmessaging/security/passwords/hashes/bcrypt/BCryptPasswordHasher.java
+++ b/src/main/java/io/mapsmessaging/security/passwords/hashes/bcrypt/BCryptPasswordHasher.java
@@ -23,7 +23,7 @@ import io.mapsmessaging.security.passwords.PasswordBuffer;
 import io.mapsmessaging.security.passwords.PasswordHasher;
 import io.mapsmessaging.security.util.ArrayHelper;
 
-public abstract class BCryptPasswordHasher implements PasswordHasher {
+public abstract class BCryptPasswordHasher extends PasswordHasher {
 
   private static final int SALT_SIZE = 22;
   private static final int DEFAULT_COST = 12;
@@ -88,8 +88,8 @@ public abstract class BCryptPasswordHasher implements PasswordHasher {
   }
 
   @Override
-  public char[] getPassword() {
-    return password.getHash();
+  public PasswordBuffer getPassword() {
+    return password;
   }
 
   @Override

--- a/src/main/java/io/mapsmessaging/security/passwords/hashes/md5/Md5PasswordHasher.java
+++ b/src/main/java/io/mapsmessaging/security/passwords/hashes/md5/Md5PasswordHasher.java
@@ -16,23 +16,24 @@
 
 package io.mapsmessaging.security.passwords.hashes.md5;
 
+import io.mapsmessaging.security.passwords.PasswordBuffer;
 import io.mapsmessaging.security.passwords.PasswordHasher;
 import io.mapsmessaging.security.util.ArrayHelper;
 import org.apache.commons.codec.digest.Md5Crypt;
 
 public class Md5PasswordHasher implements PasswordHasher {
 
-  protected final char[] password;
+  protected final PasswordBuffer password;
   protected final byte[] salt;
 
   public Md5PasswordHasher() {
-    password = new char[0];
+    password = new PasswordBuffer(new char[0]);
     salt = new byte[0];
   }
 
   protected Md5PasswordHasher(char[] password) {
     if (password == null || password.length == 0) {
-      this.password = new char[0];
+      this.password = new PasswordBuffer(new char[0]);
       this.salt = new byte[0];
     } else {
       char[] sub = ArrayHelper.substring(password, getKey().length());
@@ -46,7 +47,7 @@ public class Md5PasswordHasher implements PasswordHasher {
         pw = ArrayHelper.substring(sub, split + 1);
       }
 
-      this.password = pw;
+      this.password = new PasswordBuffer(pw);
       this.salt = ArrayHelper.charArrayToByteArray(sl);
 
       // Clear temporary arrays to avoid sensitive data lingering in memory
@@ -81,12 +82,12 @@ public class Md5PasswordHasher implements PasswordHasher {
 
   @Override
   public char[] getPassword() {
-    return password;
+    return password.getHash();
   }
 
   @Override
   public char[] getFullPasswordHash() {
-    return (getKey() + new String(salt) + "$" + new String(password)).toCharArray();
+    return ArrayHelper.appendCharArrays(getKey().toCharArray(), ArrayHelper.byteArrayToCharArray(salt), "$".toCharArray(), password.getHash());
   }
 
   @Override

--- a/src/main/java/io/mapsmessaging/security/passwords/hashes/md5/Md5PasswordHasher.java
+++ b/src/main/java/io/mapsmessaging/security/passwords/hashes/md5/Md5PasswordHasher.java
@@ -1,11 +1,11 @@
 /*
  * Copyright [ 2020 - 2024 ] [Matthew Buckton]
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -17,39 +17,45 @@
 package io.mapsmessaging.security.passwords.hashes.md5;
 
 import io.mapsmessaging.security.passwords.PasswordHasher;
+import io.mapsmessaging.security.util.ArrayHelper;
 import org.apache.commons.codec.digest.Md5Crypt;
-
-import java.nio.charset.StandardCharsets;
 
 public class Md5PasswordHasher implements PasswordHasher {
 
-  protected final byte[] password;
+  protected final char[] password;
   protected final byte[] salt;
 
   public Md5PasswordHasher() {
-    password = new byte[0];
+    password = new char[0];
     salt = new byte[0];
   }
 
-  protected Md5PasswordHasher(String password) {
-    if (password.isEmpty()) {
-      this.password = new byte[0];
-      salt = new byte[0];
+  protected Md5PasswordHasher(char[] password) {
+    if (password == null || password.length == 0) {
+      this.password = new char[0];
+      this.salt = new byte[0];
     } else {
-      String sub = password.substring(getKey().length());
-      int split = sub.indexOf("$");
-      String pw = "";
-      String sl = "";
+      char[] sub = ArrayHelper.substring(password, getKey().length());
+      int split = ArrayHelper.indexOf(sub, '$');
+
+      char[] pw = new char[0];
+      char[] sl = new char[0];
+
       if (split != -1) {
-        sl = sub.substring(0, split);
-        pw = sub.substring(split + 1);
+        sl = ArrayHelper.substring(sub, 0, split);
+        pw = ArrayHelper.substring(sub, split + 1);
       }
-      this.password = pw.getBytes(StandardCharsets.UTF_8);
-      this.salt = sl.getBytes(StandardCharsets.UTF_8);
+
+      this.password = pw;
+      this.salt = ArrayHelper.charArrayToByteArray(sl);
+
+      // Clear temporary arrays to avoid sensitive data lingering in memory
+      ArrayHelper.clearCharArray(sub);
+      ArrayHelper.clearCharArray(sl);
     }
   }
 
-  public PasswordHasher create(String password) {
+  public PasswordHasher create(char[] password) {
     return new Md5PasswordHasher(password);
   }
 
@@ -64,8 +70,8 @@ public class Md5PasswordHasher implements PasswordHasher {
   }
 
   @Override
-  public byte[] transformPassword(byte[] password, byte[] salt, int cost) {
-    return Md5Crypt.apr1Crypt(password, new String(salt)).getBytes(StandardCharsets.UTF_8);
+  public char[] transformPassword(char[] password, byte[] salt, int cost) {
+    return Md5Crypt.apr1Crypt(ArrayHelper.charArrayToByteArray(password), new String(salt)).toCharArray();
   }
 
   @Override
@@ -74,7 +80,7 @@ public class Md5PasswordHasher implements PasswordHasher {
   }
 
   @Override
-  public byte[] getPassword() {
+  public char[] getPassword() {
     return password;
   }
 

--- a/src/main/java/io/mapsmessaging/security/passwords/hashes/md5/Md5PasswordHasher.java
+++ b/src/main/java/io/mapsmessaging/security/passwords/hashes/md5/Md5PasswordHasher.java
@@ -21,7 +21,7 @@ import io.mapsmessaging.security.passwords.PasswordHasher;
 import io.mapsmessaging.security.util.ArrayHelper;
 import org.apache.commons.codec.digest.Md5Crypt;
 
-public class Md5PasswordHasher implements PasswordHasher {
+public class Md5PasswordHasher extends PasswordHasher {
 
   protected final PasswordBuffer password;
   protected final byte[] salt;
@@ -81,8 +81,8 @@ public class Md5PasswordHasher implements PasswordHasher {
   }
 
   @Override
-  public char[] getPassword() {
-    return password.getHash();
+  public PasswordBuffer getPassword() {
+    return password;
   }
 
   @Override

--- a/src/main/java/io/mapsmessaging/security/passwords/hashes/md5/Md5UnixPasswordHasher.java
+++ b/src/main/java/io/mapsmessaging/security/passwords/hashes/md5/Md5UnixPasswordHasher.java
@@ -1,11 +1,11 @@
 /*
  * Copyright [ 2020 - 2024 ] [Matthew Buckton]
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -17,9 +17,8 @@
 package io.mapsmessaging.security.passwords.hashes.md5;
 
 import io.mapsmessaging.security.passwords.PasswordHasher;
+import io.mapsmessaging.security.util.ArrayHelper;
 import org.apache.commons.codec.digest.Md5Crypt;
-
-import java.nio.charset.StandardCharsets;
 
 public class Md5UnixPasswordHasher extends Md5PasswordHasher {
 
@@ -27,13 +26,13 @@ public class Md5UnixPasswordHasher extends Md5PasswordHasher {
     super();
   }
 
-  protected Md5UnixPasswordHasher(String password) {
+  protected Md5UnixPasswordHasher(char[] password) {
     super(password);
   }
 
   @Override
-  public byte[] transformPassword(byte[] password, byte[] salt, int cost) {
-    return Md5Crypt.md5Crypt(password, getKey() + new String(salt)).getBytes(StandardCharsets.UTF_8);
+  public char[] transformPassword(char[] password, byte[] salt, int cost) {
+    return Md5Crypt.md5Crypt(ArrayHelper.charArrayToByteArray(password), getKey() + new String(salt)).toCharArray();
   }
 
   @Override
@@ -42,7 +41,7 @@ public class Md5UnixPasswordHasher extends Md5PasswordHasher {
   }
 
   @Override
-  public PasswordHasher create(String password) {
+  public PasswordHasher create(char[] password) {
     return new Md5UnixPasswordHasher(password);
   }
 

--- a/src/main/java/io/mapsmessaging/security/passwords/hashes/multi/MultiPasswordHasher.java
+++ b/src/main/java/io/mapsmessaging/security/passwords/hashes/multi/MultiPasswordHasher.java
@@ -27,7 +27,7 @@ import java.util.ArrayList;
 import java.util.List;
 import lombok.Getter;
 
-public class MultiPasswordHasher implements PasswordHasher {
+public class MultiPasswordHasher extends PasswordHasher {
 
   @Getter
   private final List<PasswordHandler> parsers;
@@ -100,8 +100,8 @@ public class MultiPasswordHasher implements PasswordHasher {
   }
 
   @Override
-  public char[] getPassword() {
-    return password.getHash();
+  public PasswordBuffer getPassword() {
+    return password;
   }
 
   @Override

--- a/src/main/java/io/mapsmessaging/security/passwords/hashes/pbkdf2/Pbkdf2PasswordHasher.java
+++ b/src/main/java/io/mapsmessaging/security/passwords/hashes/pbkdf2/Pbkdf2PasswordHasher.java
@@ -18,7 +18,7 @@ package io.mapsmessaging.security.passwords.hashes.pbkdf2;
 
 import io.mapsmessaging.security.identity.PasswordGenerator;
 import io.mapsmessaging.security.passwords.PasswordHasher;
-import java.nio.charset.StandardCharsets;
+import io.mapsmessaging.security.util.ArrayHelper;
 import java.security.NoSuchAlgorithmException;
 import java.security.spec.InvalidKeySpecException;
 import java.util.Base64;
@@ -28,21 +28,37 @@ import javax.crypto.spec.PBEKeySpec;
 public abstract class Pbkdf2PasswordHasher implements PasswordHasher {
 
   private final byte[] salt;
-  private final byte[] hash;
-
+  private final char[] hash;
   private final int cost;
 
-  protected Pbkdf2PasswordHasher(String password) {
-    String[] split = password.split("\\$");
-    if (split.length == 4) {
-      // split[0] can be ignored since it was used to construc this class
-      cost = Integer.parseInt(split[1]);
-      salt = Base64.getDecoder().decode(split[2]);
-      hash = Base64.getDecoder().decode(split[3]);
-    } else {
+  protected Pbkdf2PasswordHasher(char[] password) {
+    // Find the positions of the dollar signs
+    int firstDollar = ArrayHelper.indexOf(password, '$');
+    int secondDollar = ArrayHelper.indexOf(password, '$', firstDollar + 1);
+    int thirdDollar = ArrayHelper.indexOf(password, '$', secondDollar + 1);
+
+    if (firstDollar == -1 || secondDollar == -1 || thirdDollar == -1) {
       cost = getIterationCount();
       salt = PasswordGenerator.generateSaltBytes(getHashByteSize());
       hash = null;
+    } else {
+      // Extract cost
+      char[] costChars = ArrayHelper.substring(password, firstDollar + 1, secondDollar);
+      cost = ArrayHelper.parseInt(costChars);
+
+      // Extract salt
+      char[] saltChars = ArrayHelper.substring(password, secondDollar + 1, thirdDollar);
+      byte[] saltBytes = ArrayHelper.charArrayToByteArray(saltChars);
+      salt = Base64.getDecoder().decode(saltBytes);
+
+      // Extract hash
+      char[] hashChars = ArrayHelper.substring(password, thirdDollar + 1);
+      byte[] hashBytes = ArrayHelper.charArrayToByteArray(hashChars);
+      hash = ArrayHelper.byteArrayToCharArray(Base64.getDecoder().decode(hashBytes));
+      ArrayHelper.clearCharArray(saltChars);
+      ArrayHelper.clearByteArray(saltBytes);
+      ArrayHelper.clearCharArray(hashChars);
+      ArrayHelper.clearByteArray(hashBytes);
     }
   }
 
@@ -64,12 +80,20 @@ public abstract class Pbkdf2PasswordHasher implements PasswordHasher {
 
   @SuppressWarnings("java:S112") // Yes we know, if the JVM is not one we support then this will happen
   @Override
-  public byte[] transformPassword(byte[] password, byte[] salt, int cost) {
+  public char[] transformPassword(char[] password, byte[] salt, int cost) {
     try {
-      PBEKeySpec spec = new PBEKeySpec(new String(password).toCharArray(), salt, cost, getHashByteSize());
+      PBEKeySpec spec = new PBEKeySpec(password, salt, cost, getHashByteSize());
       SecretKeyFactory skf = SecretKeyFactory.getInstance(getAlgorithm());
       byte[] hash1 = skf.generateSecret(spec).getEncoded();
-      return (getKey() + "$" + cost + "$" + Base64.getEncoder().encodeToString(salt) + "$" + Base64.getEncoder().encodeToString(hash1)).getBytes(StandardCharsets.UTF_8);
+      return (
+          getKey() +
+              "$" +
+              cost +
+              "$" +
+              Base64.getEncoder().encodeToString(salt) +
+              "$" +
+              Base64.getEncoder().encodeToString(hash1)
+      ).toCharArray();
     } catch (NoSuchAlgorithmException | InvalidKeySpecException e) {
       throw new RuntimeException("Error while hashing password", e);
     }
@@ -81,13 +105,20 @@ public abstract class Pbkdf2PasswordHasher implements PasswordHasher {
   }
 
   @Override
-  public byte[] getPassword() {
+  public char[] getPassword() {
     return hash;
   }
 
   @Override
   public char[] getFullPasswordHash() {
-    return (getKey() + "$" + cost + "$" + Base64.getEncoder().encodeToString(salt) + "$" + Base64.getEncoder().encodeToString(hash)).toCharArray();
+    return (getKey() +
+        "$" +
+        cost +
+        "$" +
+        Base64.getEncoder().encodeToString(salt) +
+        "$" +
+        Base64.getEncoder().encodeToString(ArrayHelper.charArrayToByteArray(hash))
+    ).toCharArray();
   }
 
   @Override

--- a/src/main/java/io/mapsmessaging/security/passwords/hashes/pbkdf2/Pbkdf2PasswordHasher.java
+++ b/src/main/java/io/mapsmessaging/security/passwords/hashes/pbkdf2/Pbkdf2PasswordHasher.java
@@ -26,7 +26,7 @@ import java.util.Base64;
 import javax.crypto.SecretKeyFactory;
 import javax.crypto.spec.PBEKeySpec;
 
-public abstract class Pbkdf2PasswordHasher implements PasswordHasher {
+public abstract class Pbkdf2PasswordHasher extends PasswordHasher {
 
   private final byte[] salt;
   private final PasswordBuffer hash;
@@ -106,8 +106,8 @@ public abstract class Pbkdf2PasswordHasher implements PasswordHasher {
   }
 
   @Override
-  public char[] getPassword() {
-    return hash.getHash();
+  public PasswordBuffer getPassword() {
+    return hash;
   }
 
   @Override

--- a/src/main/java/io/mapsmessaging/security/passwords/hashes/pbkdf2/Pbkdf2Sha256PasswordHasher.java
+++ b/src/main/java/io/mapsmessaging/security/passwords/hashes/pbkdf2/Pbkdf2Sha256PasswordHasher.java
@@ -24,10 +24,10 @@ public class Pbkdf2Sha256PasswordHasher extends Pbkdf2PasswordHasher {
   private static final int PBKDF2_ITERATIONS = 10000;
 
   public Pbkdf2Sha256PasswordHasher() {
-    super("");
+    super(new char[0]);
   }
 
-  public Pbkdf2Sha256PasswordHasher(String password) {
+  public Pbkdf2Sha256PasswordHasher(char[] password) {
     super(password);
   }
 
@@ -42,7 +42,7 @@ public class Pbkdf2Sha256PasswordHasher extends Pbkdf2PasswordHasher {
   }
 
   @Override
-  public PasswordHasher create(String password) {
+  public PasswordHasher create(char[] password) {
     return new Pbkdf2Sha256PasswordHasher(password);
   }
 

--- a/src/main/java/io/mapsmessaging/security/passwords/hashes/pbkdf2/Pbkdf2Sha3256PasswordHasher.java
+++ b/src/main/java/io/mapsmessaging/security/passwords/hashes/pbkdf2/Pbkdf2Sha3256PasswordHasher.java
@@ -25,10 +25,10 @@ public class Pbkdf2Sha3256PasswordHasher extends Pbkdf2Sha3PasswordHasher {
   private static final int PBKDF2_ITERATIONS = 10000;
 
   public Pbkdf2Sha3256PasswordHasher() {
-    super("");
+    super(new char[0]);
   }
 
-  public Pbkdf2Sha3256PasswordHasher(String password) {
+  public Pbkdf2Sha3256PasswordHasher(char[] password) {
     super(password);
   }
 
@@ -43,7 +43,7 @@ public class Pbkdf2Sha3256PasswordHasher extends Pbkdf2Sha3PasswordHasher {
   }
 
   @Override
-  public PasswordHasher create(String password) {
+  public PasswordHasher create(char[] password) {
     return new Pbkdf2Sha3256PasswordHasher(password);
   }
 

--- a/src/main/java/io/mapsmessaging/security/passwords/hashes/pbkdf2/Pbkdf2Sha3PasswordHasher.java
+++ b/src/main/java/io/mapsmessaging/security/passwords/hashes/pbkdf2/Pbkdf2Sha3PasswordHasher.java
@@ -16,7 +16,7 @@
 
 package io.mapsmessaging.security.passwords.hashes.pbkdf2;
 
-import java.nio.charset.StandardCharsets;
+import io.mapsmessaging.security.util.ArrayHelper;
 import java.util.Base64;
 import org.bouncycastle.crypto.digests.SHA3Digest;
 import org.bouncycastle.crypto.generators.PKCS5S2ParametersGenerator;
@@ -24,15 +24,15 @@ import org.bouncycastle.crypto.params.KeyParameter;
 
 public abstract class Pbkdf2Sha3PasswordHasher extends Pbkdf2PasswordHasher {
 
-  protected Pbkdf2Sha3PasswordHasher(String password) {
+  protected Pbkdf2Sha3PasswordHasher(char[] password) {
     super(password);
   }
 
   @Override
-  public byte[] transformPassword(byte[] password, byte[] salt, int cost) {
+  public char[] transformPassword(char[] password, byte[] salt, int cost) {
     PKCS5S2ParametersGenerator generator =
         new PKCS5S2ParametersGenerator((new SHA3Digest(getHashByteSize() * 8)));
-    generator.init(password, salt, cost);
+    generator.init(ArrayHelper.charArrayToByteArray(password), salt, cost);
     byte[] hash =
         ((KeyParameter) generator.generateDerivedParameters(getHashByteSize() * 8)).getKey();
     return (getKey()
@@ -42,6 +42,6 @@ public abstract class Pbkdf2Sha3PasswordHasher extends Pbkdf2PasswordHasher {
             + Base64.getEncoder().encodeToString(salt)
             + "$"
             + Base64.getEncoder().encodeToString(hash))
-        .getBytes(StandardCharsets.UTF_8);
+        .toCharArray();
   }
 }

--- a/src/main/java/io/mapsmessaging/security/passwords/hashes/pbkdf2/Pbkdf2Sha512PasswordHasher.java
+++ b/src/main/java/io/mapsmessaging/security/passwords/hashes/pbkdf2/Pbkdf2Sha512PasswordHasher.java
@@ -25,10 +25,10 @@ public class Pbkdf2Sha512PasswordHasher extends Pbkdf2PasswordHasher {
   private static final int PBKDF2_ITERATIONS = 10000;
 
   public Pbkdf2Sha512PasswordHasher() {
-    super("");
+    super(new char[0]);
   }
 
-  public Pbkdf2Sha512PasswordHasher(String password) {
+  public Pbkdf2Sha512PasswordHasher(char[] password) {
     super(password);
   }
 
@@ -43,7 +43,7 @@ public class Pbkdf2Sha512PasswordHasher extends Pbkdf2PasswordHasher {
   }
 
   @Override
-  public PasswordHasher create(String password) {
+  public PasswordHasher create(char[] password) {
     return new Pbkdf2Sha512PasswordHasher(password);
   }
 

--- a/src/main/java/io/mapsmessaging/security/passwords/hashes/pbkdf2/Pdkdf2Sha3512PasswordHasher.java
+++ b/src/main/java/io/mapsmessaging/security/passwords/hashes/pbkdf2/Pdkdf2Sha3512PasswordHasher.java
@@ -25,10 +25,10 @@ public class Pdkdf2Sha3512PasswordHasher extends Pbkdf2Sha3PasswordHasher {
   private static final int PBKDF2_ITERATIONS = 10000;
 
   public Pdkdf2Sha3512PasswordHasher() {
-    super("");
+    super(new char[0]);
   }
 
-  public Pdkdf2Sha3512PasswordHasher(String password) {
+  public Pdkdf2Sha3512PasswordHasher(char[] password) {
     super(password);
   }
 
@@ -43,7 +43,7 @@ public class Pdkdf2Sha3512PasswordHasher extends Pbkdf2Sha3PasswordHasher {
   }
 
   @Override
-  public PasswordHasher create(String password) {
+  public PasswordHasher create(char[] password) {
     return new Pdkdf2Sha3512PasswordHasher(password);
   }
 

--- a/src/main/java/io/mapsmessaging/security/passwords/hashes/plain/PlainPasswordHasher.java
+++ b/src/main/java/io/mapsmessaging/security/passwords/hashes/plain/PlainPasswordHasher.java
@@ -80,4 +80,9 @@ public class PlainPasswordHasher implements PasswordHasher {
   public String getName() {
     return "PLAIN";
   }
+
+  @Override
+  public boolean matches(char[] attemptedPassword) {
+    return Arrays.equals(attemptedPassword, getPassword());
+  }
 }

--- a/src/main/java/io/mapsmessaging/security/passwords/hashes/plain/PlainPasswordHasher.java
+++ b/src/main/java/io/mapsmessaging/security/passwords/hashes/plain/PlainPasswordHasher.java
@@ -1,11 +1,11 @@
 /*
  * Copyright [ 2020 - 2024 ] [Matthew Buckton]
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -17,27 +17,28 @@
 package io.mapsmessaging.security.passwords.hashes.plain;
 
 import io.mapsmessaging.security.passwords.PasswordHasher;
-
-import java.nio.charset.StandardCharsets;
+import io.mapsmessaging.security.util.ArrayHelper;
+import java.util.Arrays;
 
 public class PlainPasswordHasher implements PasswordHasher {
 
-  private final byte[] password;
+  private final char[] password;
 
   public PlainPasswordHasher() {
-    password = new byte[0];
+    password = new char[0];
   }
 
-  public PlainPasswordHasher(String password) {
-    int ind = password.indexOf("$");
+  public PlainPasswordHasher(char[] pw) {
+    int ind = ArrayHelper.indexOf(pw, '$', 1);
     if (ind != -1) {
-      this.password = password.substring(ind + 1).getBytes(StandardCharsets.UTF_8);
-    } else {
-      this.password = password.getBytes(StandardCharsets.UTF_8);
+      pw = ArrayHelper.substring(pw, ind + 1);
     }
+    password = Arrays.copyOf(pw, pw.length);
+    // Clear the original password array to avoid lingering sensitive data
+    ArrayHelper.clearCharArray(pw);
   }
 
-  public PasswordHasher create(String password) {
+  public PasswordHasher create(char[] password) {
     return new PlainPasswordHasher(password);
   }
 
@@ -52,9 +53,9 @@ public class PlainPasswordHasher implements PasswordHasher {
   }
 
   @Override
-  public byte[] transformPassword(byte[] password, byte[] salt, int cost) {
-    byte[] tmp = (getName() + "$").getBytes(StandardCharsets.UTF_8);
-    byte[] response = new byte[tmp.length + password.length];
+  public char[] transformPassword(char[] password, byte[] salt, int cost) {
+    char[] tmp = (getName() + "$").toCharArray();
+    char[] response = new char[tmp.length + password.length];
     System.arraycopy(tmp, 0, response, 0, tmp.length);
     System.arraycopy(password, 0, response, tmp.length, password.length);
     return response;
@@ -66,7 +67,7 @@ public class PlainPasswordHasher implements PasswordHasher {
   }
 
   @Override
-  public byte[] getPassword() {
+  public char[] getPassword() {
     return password;
   }
 

--- a/src/main/java/io/mapsmessaging/security/passwords/hashes/plain/PlainPasswordHasher.java
+++ b/src/main/java/io/mapsmessaging/security/passwords/hashes/plain/PlainPasswordHasher.java
@@ -16,16 +16,17 @@
 
 package io.mapsmessaging.security.passwords.hashes.plain;
 
+import io.mapsmessaging.security.passwords.PasswordBuffer;
 import io.mapsmessaging.security.passwords.PasswordHasher;
 import io.mapsmessaging.security.util.ArrayHelper;
 import java.util.Arrays;
 
-public class PlainPasswordHasher implements PasswordHasher {
+public class PlainPasswordHasher extends PasswordHasher {
 
-  private final char[] password;
+  private final PasswordBuffer password;
 
   public PlainPasswordHasher() {
-    password = new char[0];
+    password = new PasswordBuffer(new char[0]);
   }
 
   public PlainPasswordHasher(char[] pw) {
@@ -33,7 +34,7 @@ public class PlainPasswordHasher implements PasswordHasher {
     if (ind != -1) {
       pw = ArrayHelper.substring(pw, ind + 1);
     }
-    password = Arrays.copyOf(pw, pw.length);
+    password = new PasswordBuffer(Arrays.copyOf(pw, pw.length));
     // Clear the original password array to avoid lingering sensitive data
     ArrayHelper.clearCharArray(pw);
   }
@@ -67,13 +68,13 @@ public class PlainPasswordHasher implements PasswordHasher {
   }
 
   @Override
-  public char[] getPassword() {
+  public PasswordBuffer getPassword() {
     return password;
   }
 
   @Override
   public char[] getFullPasswordHash() {
-    return (getName() + "$" + new String(password)).toCharArray();
+    return ArrayHelper.appendCharArrays(getName().toCharArray(), "$".toCharArray(), password.getHash());
   }
 
   @Override
@@ -83,6 +84,6 @@ public class PlainPasswordHasher implements PasswordHasher {
 
   @Override
   public boolean matches(char[] attemptedPassword) {
-    return Arrays.equals(attemptedPassword, getPassword());
+    return Arrays.equals(attemptedPassword, getPassword().getHash());
   }
 }

--- a/src/main/java/io/mapsmessaging/security/passwords/hashes/sha/Sha1PasswordHasher.java
+++ b/src/main/java/io/mapsmessaging/security/passwords/hashes/sha/Sha1PasswordHasher.java
@@ -16,6 +16,7 @@
 
 package io.mapsmessaging.security.passwords.hashes.sha;
 
+import io.mapsmessaging.security.passwords.PasswordBuffer;
 import io.mapsmessaging.security.passwords.PasswordHasher;
 import io.mapsmessaging.security.util.ArrayHelper;
 import org.apache.commons.codec.binary.Base64;
@@ -23,10 +24,10 @@ import org.apache.commons.codec.digest.DigestUtils;
 
 public class Sha1PasswordHasher implements PasswordHasher {
 
-  private final char[] password;
+  private final PasswordBuffer password;
 
   public Sha1PasswordHasher() {
-    password = new char[0];
+    password = new PasswordBuffer(new char[0]);
   }
 
   protected Sha1PasswordHasher(char[] pw) {
@@ -34,7 +35,7 @@ public class Sha1PasswordHasher implements PasswordHasher {
     if (ArrayHelper.startsWithIgnoreCase(pw, key)) {
       pw = ArrayHelper.substring(pw, key.length);
     }
-    password = pw;
+    password = new PasswordBuffer(pw);
   }
 
   public PasswordHasher create(char[] password) {
@@ -64,12 +65,12 @@ public class Sha1PasswordHasher implements PasswordHasher {
 
   @Override
   public char[] getPassword() {
-    return password;
+    return password.getHash();
   }
 
   @Override
   public char[] getFullPasswordHash() {
-    return (getKey() + new String(password)).toCharArray();
+    return ArrayHelper.appendCharArrays(getKey().toCharArray(), password.getHash());
   }
 
   @Override

--- a/src/main/java/io/mapsmessaging/security/passwords/hashes/sha/Sha1PasswordHasher.java
+++ b/src/main/java/io/mapsmessaging/security/passwords/hashes/sha/Sha1PasswordHasher.java
@@ -17,26 +17,27 @@
 package io.mapsmessaging.security.passwords.hashes.sha;
 
 import io.mapsmessaging.security.passwords.PasswordHasher;
-import java.nio.charset.StandardCharsets;
+import io.mapsmessaging.security.util.ArrayHelper;
 import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.codec.digest.DigestUtils;
 
 public class Sha1PasswordHasher implements PasswordHasher {
 
-  private final byte[] password;
+  private final char[] password;
 
   public Sha1PasswordHasher() {
-    password = new byte[0];
+    password = new char[0];
   }
 
-  protected Sha1PasswordHasher(String password) {
-    if(password.toLowerCase().startsWith(getKey().toLowerCase())){
-      password = password.substring(getKey().length());
+  protected Sha1PasswordHasher(char[] pw) {
+    char[] key = getKey().toCharArray();
+    if (ArrayHelper.startsWithIgnoreCase(pw, key)) {
+      pw = ArrayHelper.substring(pw, key.length);
     }
-    this.password = password.getBytes(StandardCharsets.UTF_8);
+    password = pw;
   }
 
-  public PasswordHasher create(String password) {
+  public PasswordHasher create(char[] password) {
     return new Sha1PasswordHasher(password);
   }
 
@@ -52,8 +53,8 @@ public class Sha1PasswordHasher implements PasswordHasher {
 
   @SuppressWarnings("java:S4790") // this is weak but used to test
   @Override
-  public byte[] transformPassword(byte[] password, byte[] salt, int cost) {
-    return (getKey() + Base64.encodeBase64String(DigestUtils.sha1(password))).getBytes(StandardCharsets.UTF_8);
+  public char[] transformPassword(char[] password, byte[] salt, int cost) {
+    return (getKey() + Base64.encodeBase64String(DigestUtils.sha1(ArrayHelper.charArrayToByteArray(password)))).toCharArray();
   }
 
   @Override
@@ -62,7 +63,7 @@ public class Sha1PasswordHasher implements PasswordHasher {
   }
 
   @Override
-  public byte[] getPassword() {
+  public char[] getPassword() {
     return password;
   }
 

--- a/src/main/java/io/mapsmessaging/security/passwords/hashes/sha/Sha1PasswordHasher.java
+++ b/src/main/java/io/mapsmessaging/security/passwords/hashes/sha/Sha1PasswordHasher.java
@@ -22,7 +22,7 @@ import io.mapsmessaging.security.util.ArrayHelper;
 import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.codec.digest.DigestUtils;
 
-public class Sha1PasswordHasher implements PasswordHasher {
+public class Sha1PasswordHasher extends PasswordHasher {
 
   private final PasswordBuffer password;
 
@@ -64,8 +64,8 @@ public class Sha1PasswordHasher implements PasswordHasher {
   }
 
   @Override
-  public char[] getPassword() {
-    return password.getHash();
+  public PasswordBuffer getPassword() {
+    return password;
   }
 
   @Override

--- a/src/main/java/io/mapsmessaging/security/passwords/hashes/sha/UnixSha256PasswordHasher.java
+++ b/src/main/java/io/mapsmessaging/security/passwords/hashes/sha/UnixSha256PasswordHasher.java
@@ -1,11 +1,11 @@
 /*
  * Copyright [ 2020 - 2024 ] [Matthew Buckton]
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -20,18 +20,18 @@ import io.mapsmessaging.security.passwords.PasswordHasher;
 
 public class UnixSha256PasswordHasher extends UnixShaPasswordHasher {
 
-  private static final String KEY = "$5$";
+  private static final char[] KEY = "$5$".toCharArray();
 
   public UnixSha256PasswordHasher() {
-    this(KEY);
+    this(new char[0]);
   }
 
-  public UnixSha256PasswordHasher(String password) {
+  public UnixSha256PasswordHasher(char[] password) {
     super(KEY, password);
   }
 
   @Override
-  public PasswordHasher create(String password) {
+  public PasswordHasher create(char[] password) {
     return new UnixSha256PasswordHasher(password);
   }
 

--- a/src/main/java/io/mapsmessaging/security/passwords/hashes/sha/UnixSha512PasswordHasher.java
+++ b/src/main/java/io/mapsmessaging/security/passwords/hashes/sha/UnixSha512PasswordHasher.java
@@ -1,11 +1,11 @@
 /*
  * Copyright [ 2020 - 2024 ] [Matthew Buckton]
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -20,18 +20,18 @@ import io.mapsmessaging.security.passwords.PasswordHasher;
 
 public class UnixSha512PasswordHasher extends UnixShaPasswordHasher {
 
-  private static final String KEY = "$6$";
+  private static final char[] KEY = "$6$".toCharArray();
 
   public UnixSha512PasswordHasher() {
-    this(KEY);
+    this(new char[0]);
   }
 
-  public UnixSha512PasswordHasher(String password) {
+  public UnixSha512PasswordHasher(char[] password) {
     super(KEY, password);
   }
 
   @Override
-  public PasswordHasher create(String password) {
+  public PasswordHasher create(char[] password) {
     return new UnixSha512PasswordHasher(password);
   }
 

--- a/src/main/java/io/mapsmessaging/security/passwords/hashes/sha/UnixShaPasswordHasher.java
+++ b/src/main/java/io/mapsmessaging/security/passwords/hashes/sha/UnixShaPasswordHasher.java
@@ -23,7 +23,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import org.apache.commons.codec.digest.Crypt;
 
-public abstract class UnixShaPasswordHasher implements PasswordHasher {
+public abstract class UnixShaPasswordHasher extends PasswordHasher {
 
   private final PasswordBuffer password;
   private final String salt;
@@ -90,8 +90,8 @@ public abstract class UnixShaPasswordHasher implements PasswordHasher {
   }
 
   @Override
-  public char[] getPassword() {
-    return password.getHash();
+  public PasswordBuffer getPassword() {
+    return password;
   }
 
   @Override

--- a/src/main/java/io/mapsmessaging/security/passwords/hashes/sha/UnixShaPasswordHasher.java
+++ b/src/main/java/io/mapsmessaging/security/passwords/hashes/sha/UnixShaPasswordHasher.java
@@ -16,6 +16,7 @@
 
 package io.mapsmessaging.security.passwords.hashes.sha;
 
+import io.mapsmessaging.security.passwords.PasswordBuffer;
 import io.mapsmessaging.security.passwords.PasswordHasher;
 import io.mapsmessaging.security.util.ArrayHelper;
 import java.nio.charset.StandardCharsets;
@@ -24,7 +25,7 @@ import org.apache.commons.codec.digest.Crypt;
 
 public abstract class UnixShaPasswordHasher implements PasswordHasher {
 
-  private final char[] password;
+  private final PasswordBuffer password;
   private final String salt;
   private final char[] key;
 
@@ -32,7 +33,7 @@ public abstract class UnixShaPasswordHasher implements PasswordHasher {
     this.key = key;
     if (pw.length == 0) {
       salt = "";
-      password = new char[0];
+      password = new PasswordBuffer(new char[0]);
     } else {
       char[] subPassword = ArrayHelper.substring(pw, key.length);
       int idx = ArrayHelper.indexOf(subPassword, '$');
@@ -40,13 +41,13 @@ public abstract class UnixShaPasswordHasher implements PasswordHasher {
         char[] saltChars = ArrayHelper.substring(subPassword, 0, idx);
         char[] remainingPassword = ArrayHelper.substring(subPassword, idx + 1);
         salt = new String(saltChars);
-        password = Arrays.copyOf(remainingPassword, remainingPassword.length);
+        password = new PasswordBuffer(Arrays.copyOf(remainingPassword, remainingPassword.length));
 
         // Clear sensitive data
         ArrayHelper.clearCharArray(saltChars);
         ArrayHelper.clearCharArray(remainingPassword);
       } else {
-        password = new char[0];
+        password = new PasswordBuffer(new char[0]);
         salt = "";
       }
 
@@ -90,12 +91,12 @@ public abstract class UnixShaPasswordHasher implements PasswordHasher {
 
   @Override
   public char[] getPassword() {
-    return password;
+    return password.getHash();
   }
 
   @Override
   public char[] getFullPasswordHash() {
-    return (getKey() + salt + "$" + new String(password)).toCharArray();
+    return ArrayHelper.appendCharArrays(getKey().toCharArray(), salt.toCharArray(), "$".toCharArray(), password.getHash());
   }
 
   @Override

--- a/src/main/java/io/mapsmessaging/security/passwords/hashes/sha/UnixShaPasswordHasher.java
+++ b/src/main/java/io/mapsmessaging/security/passwords/hashes/sha/UnixShaPasswordHasher.java
@@ -17,37 +17,47 @@
 package io.mapsmessaging.security.passwords.hashes.sha;
 
 import io.mapsmessaging.security.passwords.PasswordHasher;
+import io.mapsmessaging.security.util.ArrayHelper;
 import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
 import org.apache.commons.codec.digest.Crypt;
 
 public abstract class UnixShaPasswordHasher implements PasswordHasher {
 
-  private final byte[] password;
+  private final char[] password;
   private final String salt;
-  private final String key;
+  private final char[] key;
 
-  protected UnixShaPasswordHasher(String key, String password) {
+  protected UnixShaPasswordHasher(char[] key, char[] pw) {
     this.key = key;
-    if (password.isEmpty()) {
+    if (pw.length == 0) {
       salt = "";
-      this.password = new byte[0];
+      password = new char[0];
     } else {
-      password = password.substring(key.length());
-      int idx = password.indexOf("$");
+      char[] subPassword = ArrayHelper.substring(pw, key.length);
+      int idx = ArrayHelper.indexOf(subPassword, '$');
       if (idx > 0) {
-        salt = password.substring(0, idx);
-        password = password.substring(idx + 1);
-        this.password = password.getBytes(StandardCharsets.UTF_8);
+        char[] saltChars = ArrayHelper.substring(subPassword, 0, idx);
+        char[] remainingPassword = ArrayHelper.substring(subPassword, idx + 1);
+        salt = new String(saltChars);
+        password = Arrays.copyOf(remainingPassword, remainingPassword.length);
+
+        // Clear sensitive data
+        ArrayHelper.clearCharArray(saltChars);
+        ArrayHelper.clearCharArray(remainingPassword);
       } else {
-        this.password = new byte[0];
+        password = new char[0];
         salt = "";
       }
+
+      // Clear sensitive data
+      ArrayHelper.clearCharArray(subPassword);
     }
   }
 
   @Override
   public String getKey() {
-    return key;
+    return new String(key);
   }
 
   @Override
@@ -56,10 +66,10 @@ public abstract class UnixShaPasswordHasher implements PasswordHasher {
   }
 
   @Override
-  public byte[] transformPassword(byte[] password, byte[] salt, int cost) {
+  public char[] transformPassword(char[] password, byte[] salt, int cost) {
     boolean headerOk = true;
     byte[] packedSalt = salt;
-    byte[] keyBytes = key.getBytes(StandardCharsets.UTF_8);
+    byte[] keyBytes = ArrayHelper.charArrayToByteArray(key);
     for (int x = 0; x < keyBytes.length; x++) {
       if (salt[x] != keyBytes[x]) {
         headerOk = false;
@@ -67,10 +77,10 @@ public abstract class UnixShaPasswordHasher implements PasswordHasher {
       }
     }
     if (!headerOk) {
-      packedSalt = (key + new String(salt)).getBytes(StandardCharsets.UTF_8);
+      packedSalt = (getKey() + new String(salt)).getBytes(StandardCharsets.UTF_8);
     }
-    String hash = Crypt.crypt(password, new String(packedSalt));
-    return hash.getBytes(StandardCharsets.UTF_8);
+    String hash = Crypt.crypt(ArrayHelper.charArrayToByteArray(password), new String(packedSalt));
+    return hash.toCharArray();
   }
 
   @Override
@@ -79,13 +89,13 @@ public abstract class UnixShaPasswordHasher implements PasswordHasher {
   }
 
   @Override
-  public byte[] getPassword() {
+  public char[] getPassword() {
     return password;
   }
 
   @Override
   public char[] getFullPasswordHash() {
-    return (key + salt + "$" + new String(password)).toCharArray();
+    return (getKey() + salt + "$" + new String(password)).toCharArray();
   }
 
   @Override

--- a/src/main/java/io/mapsmessaging/security/sasl/SaslPrep.java
+++ b/src/main/java/io/mapsmessaging/security/sasl/SaslPrep.java
@@ -44,6 +44,11 @@ public class SaslPrep {
     return profile.prepareStored(string);
   }
 
+  // Implements RFC rfc4013
+  public char[] stringPrep(char[] string) {
+    return profile.prepareStored(string);
+  }
+
   private SaslPrep() {
     profile = Stringprep.getProvider("SASLprep");
   }

--- a/src/main/java/io/mapsmessaging/security/sasl/provider/scram/SessionContext.java
+++ b/src/main/java/io/mapsmessaging/security/sasl/provider/scram/SessionContext.java
@@ -143,9 +143,9 @@ public class SessionContext {
     clientSignature = computeHmac(storedKey, authString);
   }
 
-  public void computeClientHashes(String password, String authString)
+  public void computeClientHashes(byte[] password, String authString)
       throws InvalidKeyException, NoSuchAlgorithmException, InvalidKeySpecException {
-    computeClientKey(password.getBytes(StandardCharsets.UTF_8));
+    computeClientKey(password);
     computeStoredKeyAndSignature(authString);
     clientProof = clientKey.clone();
     for (int i = 0; i < clientProof.length; i++) {

--- a/src/main/java/io/mapsmessaging/security/sasl/provider/scram/SessionContext.java
+++ b/src/main/java/io/mapsmessaging/security/sasl/provider/scram/SessionContext.java
@@ -47,7 +47,7 @@ public class SessionContext {
   private String username;
   private State state;
   private int iterations;
-  private String prepPassword;
+  private char[] prepPassword;
   private Mac mac;
   private String algorithm;
   private int keySize;
@@ -74,7 +74,7 @@ public class SessionContext {
     initialServerChallenge = "";
     algorithm = "";
     keySize = 0;
-    prepPassword = "";
+    prepPassword = new char[0];
 
     Arrays.fill(clientKey, (byte) 0);
     Arrays.fill(clientSignature, (byte) 0);

--- a/src/main/java/io/mapsmessaging/security/sasl/provider/scram/client/state/ChallengeState.java
+++ b/src/main/java/io/mapsmessaging/security/sasl/provider/scram/client/state/ChallengeState.java
@@ -49,13 +49,13 @@ public class ChallengeState extends State {
     response.put(ChallengeResponse.NONCE, context.getServerNonce());
     response.put(ChallengeResponse.CHANNEL_BINDING, "biws");
 
-    String saltedPassword = "";
+    byte[] saltedPassword=new byte[0];
     try {
       if (context.getPasswordHasher() != null) {
         byte[] salt = Base64.getDecoder().decode(context.getPasswordSalt());
         char[] computedHash = context.getPasswordHasher().transformPassword(context.getPrepPassword(), salt, context.getIterations());
         PasswordHandler breakDown = context.getPasswordHasher().create(computedHash);
-        saltedPassword = new String(breakDown.getPassword());
+        saltedPassword = breakDown.getPassword().getBytes();
       }
 
     //
@@ -68,7 +68,7 @@ public class ChallengeState extends State {
       //
       // Compute the expected server response
       //
-      context.computeServerSignature(saltedPassword.getBytes(), authString);
+      context.computeServerSignature(saltedPassword, authString);
 
     } catch (GeneralSecurityException e) {
       SaslException saslException = new SaslException(e.getMessage());

--- a/src/main/java/io/mapsmessaging/security/sasl/provider/scram/client/state/ChallengeState.java
+++ b/src/main/java/io/mapsmessaging/security/sasl/provider/scram/client/state/ChallengeState.java
@@ -53,14 +53,8 @@ public class ChallengeState extends State {
     try {
       if (context.getPasswordHasher() != null) {
         byte[] salt = Base64.getDecoder().decode(context.getPasswordSalt());
-        byte[] computedHash =
-            context
-                .getPasswordHasher()
-                .transformPassword(
-                    context.getPrepPassword().getBytes(StandardCharsets.UTF_8),
-                    salt,
-                    context.getIterations());
-        PasswordHandler breakDown = context.getPasswordHasher().create(new String(computedHash));
+        char[] computedHash = context.getPasswordHasher().transformPassword(context.getPrepPassword(), salt, context.getIterations());
+        PasswordHandler breakDown = context.getPasswordHasher().create(computedHash);
         saltedPassword = new String(breakDown.getPassword());
       }
 

--- a/src/main/java/io/mapsmessaging/security/sasl/provider/scram/client/state/InitialState.java
+++ b/src/main/java/io/mapsmessaging/security/sasl/provider/scram/client/state/InitialState.java
@@ -57,8 +57,7 @@ public class InitialState extends State {
     //
     // Update the context
     //
-    String rawPassword = new String((((PasswordCallback) callbacks[1]).getPassword()));
-
+    char[] rawPassword = ((PasswordCallback) callbacks[1]).getPassword();
     context.setUsername(((NameCallback) callbacks[0]).getName());
     context.setPrepPassword(SaslPrep.getInstance().stringPrep(rawPassword));
 

--- a/src/main/java/io/mapsmessaging/security/sasl/provider/scram/server/state/InitialState.java
+++ b/src/main/java/io/mapsmessaging/security/sasl/provider/scram/server/state/InitialState.java
@@ -95,7 +95,7 @@ public class InitialState extends State {
     try {
       PasswordHandler handler = PasswordHandlerFactory.getInstance().parse(password);
       context.setPasswordHasher(handler);
-      context.setPrepPassword(SaslPrep.getInstance().stringPrep(handler.getPassword()));
+      context.setPrepPassword(SaslPrep.getInstance().stringPrep(handler.getPassword().getHash()));
       byte[] salt = handler.getSalt();
       if (salt == null || salt.length == 0) {
         salt = PasswordGenerator.generateSalt(64).getBytes(StandardCharsets.UTF_8);

--- a/src/main/java/io/mapsmessaging/security/sasl/provider/scram/server/state/InitialState.java
+++ b/src/main/java/io/mapsmessaging/security/sasl/provider/scram/server/state/InitialState.java
@@ -93,9 +93,9 @@ public class InitialState extends State {
 
     char[] password = ((PasswordCallback) callbacks[1]).getPassword();
     try {
-      PasswordHandler handler = PasswordHandlerFactory.getInstance().parse(new String(password));
+      PasswordHandler handler = PasswordHandlerFactory.getInstance().parse(password);
       context.setPasswordHasher(handler);
-      context.setPrepPassword(SaslPrep.getInstance().stringPrep(new String(handler.getPassword())));
+      context.setPrepPassword(SaslPrep.getInstance().stringPrep(handler.getPassword()));
       byte[] salt = handler.getSalt();
       if (salt == null || salt.length == 0) {
         salt = PasswordGenerator.generateSalt(64).getBytes(StandardCharsets.UTF_8);

--- a/src/main/java/io/mapsmessaging/security/sasl/provider/scram/server/state/ValidationState.java
+++ b/src/main/java/io/mapsmessaging/security/sasl/provider/scram/server/state/ValidationState.java
@@ -20,8 +20,8 @@ import io.mapsmessaging.security.logging.AuthLogMessages;
 import io.mapsmessaging.security.sasl.provider.scram.SessionContext;
 import io.mapsmessaging.security.sasl.provider.scram.State;
 import io.mapsmessaging.security.sasl.provider.scram.msgs.ChallengeResponse;
+import io.mapsmessaging.security.util.ArrayHelper;
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
 import java.security.spec.InvalidKeySpecException;
@@ -68,7 +68,7 @@ public class ValidationState extends State {
     String authString = client + "," + context.getInitialServerChallenge() + "," + response;
 
     try {
-      context.computeClientKey(context.getPrepPassword().getBytes(StandardCharsets.UTF_8));
+      context.computeClientKey(ArrayHelper.charArrayToByteArray(context.getPrepPassword()));
       context.computeStoredKeyAndSignature(authString);
 
       byte[] clientKey = context.getClientKey();
@@ -80,7 +80,7 @@ public class ValidationState extends State {
       if (!Arrays.equals(expectedClientProof, proof)) {
         throw new SaslException("Invalid password");
       }
-      context.computeServerSignature(context.getPrepPassword().getBytes(StandardCharsets.UTF_8), authString);
+      context.computeServerSignature(ArrayHelper.charArrayToByteArray(context.getPrepPassword()), authString);
       context.setServerSignature(context.getServerSignature());
     } catch (InvalidKeyException | NoSuchAlgorithmException e) {
       SaslException saslException = new SaslException(e.getMessage());

--- a/src/main/java/io/mapsmessaging/security/util/ArrayHelper.java
+++ b/src/main/java/io/mapsmessaging/security/util/ArrayHelper.java
@@ -16,13 +16,108 @@
 
 package io.mapsmessaging.security.util;
 
+import java.io.CharArrayWriter;
+import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.CharBuffer;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 
 public class ArrayHelper {
+
+  public static char[][] jsonArrayToCharArrays(char[] jsonArray) {
+    if (jsonArray == null || jsonArray.length < 2 || jsonArray[0] != '[' || jsonArray[jsonArray.length - 1] != ']') {
+      throw new IllegalArgumentException("Input is not a valid JSON array of strings");
+    }
+
+    List<char[]> resultList = new ArrayList<>();
+    int start = -1;
+    boolean inString = false;
+    boolean escape = false;
+
+    for (int i = 1; i < jsonArray.length - 1; i++) {
+      char c = jsonArray[i];
+      if (escape) {
+        escape = false;
+      } else if (c == '\\') {
+        escape = true;
+      } else if (c == '"') {
+        inString = !inString;
+        if (inString) {
+          start = i + 1;
+        } else {
+          resultList.add(substring(jsonArray, start, i));
+        }
+      }
+    }
+
+    return resultList.toArray(new char[resultList.size()][]);
+  }
+
+  public static char[] charArraysToJsonArray(List<char[]> charArrays) {
+    if (charArrays == null || charArrays.isEmpty()) {
+      return "[]".toCharArray();
+    }
+
+    CharArrayWriter writer = new CharArrayWriter();
+    writer.append('[');
+    for (int i = 0; i < charArrays.size(); i++) {
+      if (charArrays.get(i) != null) {
+        char[] working = charArrays.get(i);
+        writer.append('"');
+        for (char c : working) {
+          if (c == '\\' || c == '"') {
+            writer.append('\\');
+          }
+          writer.append(c);
+        }
+        clearCharArray(working);
+        writer.append('"');
+        if (i < charArrays.size() - 1) {
+          writer.append(',');
+        }
+      }
+    }
+    charArrays.clear();
+    writer.append(']');
+    char[] response = writer.toCharArray();
+    writer.reset();
+    char[] reset = new char[response.length];
+    clearCharArray(reset);
+    try {
+      writer.write(reset);
+    } catch (IOException e) {
+      // ignore
+    }
+    return response;
+  }
+
+  public static char[] appendCharArrays(char[]... arrays) {
+    // Calculate the total length of the resulting array
+    int totalLength = 0;
+    for (char[] array : arrays) {
+      if (array != null) {
+        totalLength += array.length;
+      }
+    }
+
+    // Create the resulting array
+    char[] result = new char[totalLength];
+    int currentIndex = 0;
+
+    // Copy each array into the resulting array
+    for (char[] array : arrays) {
+      if (array != null) {
+        System.arraycopy(array, 0, result, currentIndex, array.length);
+        currentIndex += array.length;
+      }
+    }
+
+    return result;
+  }
 
   public static boolean startsWithIgnoreCase(char[] input, char[] prefix) {
     if (input.length < prefix.length) {

--- a/src/main/java/io/mapsmessaging/security/util/ArrayHelper.java
+++ b/src/main/java/io/mapsmessaging/security/util/ArrayHelper.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright [ 2020 - 2024 ] [Matthew Buckton]
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.mapsmessaging.security.util;
+
+import java.nio.ByteBuffer;
+import java.nio.CharBuffer;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+
+public class ArrayHelper {
+
+  public static boolean startsWithIgnoreCase(char[] input, char[] prefix) {
+    if (input.length < prefix.length) {
+      return false;
+    }
+    for (int i = 0; i < prefix.length; i++) {
+      if (Character.toLowerCase(input[i]) != Character.toLowerCase(prefix[i])) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  public static int parseInt(char[] input) {
+    return Integer.parseInt(new String(input)); // Only convert the necessary part to String temporarily
+  }
+
+  public static int indexOf(char[] input, char ch, int start) {
+    for (int i = start; i < input.length; i++) {
+      if (input[i] == ch) {
+        return i;
+      }
+    }
+    return -1;
+  }
+
+
+  public static int indexOf(char[] input, char ch) {
+    for (int i = 0; i < input.length; i++) {
+      if (input[i] == ch) {
+        return i;
+      }
+    }
+    return -1;
+  }
+
+
+  public static char[] substring(char[] input, int start) {
+    return substring(input, start, input.length);
+  }
+
+  public static char[] substring(char[] input, int start, int end) {
+    if (start < 0 || end > input.length || start > end) {
+      throw new IndexOutOfBoundsException("Invalid substring range");
+    }
+    char[] result = new char[end - start];
+    System.arraycopy(input, start, result, 0, end - start);
+    return result;
+  }
+
+
+  public static byte[] charArrayToByteArray(char[] charArray) {
+    Charset charset = StandardCharsets.UTF_8;
+    ByteBuffer byteBuffer = charset.encode(CharBuffer.wrap(charArray));
+    byte[] byteArray = new byte[byteBuffer.remaining()];
+    byteBuffer.get(byteArray);
+    return byteArray;
+  }
+
+  public static char[] byteArrayToCharArray(byte[] byteArray) {
+    Charset charset = StandardCharsets.UTF_8;
+    CharBuffer charBuffer = charset.decode(ByteBuffer.wrap(byteArray));
+    char[] charArray = new char[charBuffer.remaining()];
+    charBuffer.get(charArray);
+    return charArray;
+  }
+
+  public static void clearCharArray(char[] charArray) {
+    if (charArray != null) {
+      Arrays.fill(charArray, '\u0000');
+    }
+  }
+
+  public static void clearByteArray(byte[] byteArray) {
+    if (byteArray != null) {
+      Arrays.fill(byteArray, (byte) 0);
+    }
+  }
+
+  private ArrayHelper(){}
+
+}

--- a/src/test/java/io/mapsmessaging/security/access/AccessControlListTest.java
+++ b/src/test/java/io/mapsmessaging/security/access/AccessControlListTest.java
@@ -57,26 +57,26 @@ public class AccessControlListTest {
     PasswordHasher passwordHasher = new BCrypt2YPasswordHasher();
     identityAccessManager.setPasswordHandler(passwordHasher);
 
-    byte[] hash =
+    char[] hash =
         passwordHasher.transformPassword(
-            "password1".getBytes(StandardCharsets.UTF_8),
+            "password1".toCharArray(),
             PasswordGenerator.generateSalt(16).getBytes(StandardCharsets.UTF_8),
             10);
-    UserIdMap usernameId = identityAccessManager.createUser("username", new String(hash));
+    UserIdMap usernameId = identityAccessManager.createUser("username", hash);
 
     hash =
         passwordHasher.transformPassword(
-            "password2".getBytes(StandardCharsets.UTF_8),
+            "password2".toCharArray(),
             PasswordGenerator.generateSalt(16).getBytes(StandardCharsets.UTF_8),
             10);
-    UserIdMap username2Id = identityAccessManager.createUser("username2", new String(hash));
+    UserIdMap username2Id = identityAccessManager.createUser("username2", hash);
 
     hash =
         passwordHasher.transformPassword(
-            "password3".getBytes(StandardCharsets.UTF_8),
+            "password3".toCharArray(),
             PasswordGenerator.generateSalt(16).getBytes(StandardCharsets.UTF_8),
             10);
-    UserIdMap fredId = identityAccessManager.createUser("fred", new String(hash));
+    UserIdMap fredId = identityAccessManager.createUser("fred", hash);
 
     GroupIdMap group1IdMap = identityAccessManager.createGroup("group1");
     GroupIdMap group2IdMap = identityAccessManager.createGroup("group2");

--- a/src/test/java/io/mapsmessaging/security/access/IdentityAccessManagerBaseTest.java
+++ b/src/test/java/io/mapsmessaging/security/access/IdentityAccessManagerBaseTest.java
@@ -114,7 +114,7 @@ public class IdentityAccessManagerBaseTest extends BaseSecurityTest {
       groupNames.add(group);
     }
 
-    Map<String, String> userPasswordMap = new LinkedHashMap<>();
+    Map<String, char[]> userPasswordMap = new LinkedHashMap<>();
     for (int x = 0; x < 100; x++) {
       Assertions.assertEquals(x, identityAccessManager.getAllUsers().size());
       String username = faker.starTrek().character();
@@ -140,7 +140,7 @@ public class IdentityAccessManagerBaseTest extends BaseSecurityTest {
         count++;
         username = username.replaceAll(" ", "_");
       }
-      String password = PasswordGenerator.generateSalt(10 + Math.abs(random.nextInt(20)));
+      char[] password = PasswordGenerator.generateSalt(10 + Math.abs(random.nextInt(20))).toCharArray();
       identityAccessManager.createUser(username, password);
       String group = groupNames.get(Math.abs(random.nextInt(groupNames.size())));
       identityAccessManager.addUserToGroup(username, group);
@@ -149,16 +149,15 @@ public class IdentityAccessManagerBaseTest extends BaseSecurityTest {
       Assertions.assertNotNull(identityAccessManager.getUser(username).getAuthId());
     }
 
-    for (Map.Entry<String, String> user : userPasswordMap.entrySet()) {
+    for (Map.Entry<String, char[]> user : userPasswordMap.entrySet()) {
       Assertions.assertTrue(validateLogin(auth, user.getKey(), user.getValue()));
-      Assertions.assertFalse(validateLogin(auth, user.getKey(), user.getValue() + "_bad_password"));
+      Assertions.assertFalse(validateLogin(auth, user.getKey(), (user.getValue() + "_bad_password").toCharArray()));
     }
 
     if (!mechanism.isEmpty()) {
-      for (Map.Entry<String, String> user : userPasswordMap.entrySet()) {
+      for (Map.Entry<String, char[]> user : userPasswordMap.entrySet()) {
         SaslTester saslTester = new SaslTester();
-        saslTester.testMechanism(
-            identityAccessManager.getIdentityLookup(), mechanism, user.getKey(), user.getValue());
+        saslTester.testMechanism(identityAccessManager.getIdentityLookup(), mechanism, user.getKey(), user.getValue());
       }
     }
 
@@ -173,7 +172,7 @@ public class IdentityAccessManagerBaseTest extends BaseSecurityTest {
     Assertions.assertEquals(0, identityAccessManager.getAllGroups().size());
   }
 
-  private boolean validateLogin(String auth, String username, String password) {
+  private boolean validateLogin(String auth, String username, char[] password) {
     Map<String, String> initMap = new LinkedHashMap<>();
     initMap.put("siteWide", auth);
     Subject subject = new Subject();

--- a/src/test/java/io/mapsmessaging/security/identity/BaseIdentityTest.java
+++ b/src/test/java/io/mapsmessaging/security/identity/BaseIdentityTest.java
@@ -32,7 +32,7 @@ public class BaseIdentityTest {
     Assertions.assertEquals(0, testIdentityLookup.getGroups().size());
     Assertions.assertThrowsExactly(NotImplementedException.class, () -> testIdentityLookup.createGroup("fred"));
     Assertions.assertThrowsExactly(NotImplementedException.class, () -> testIdentityLookup.deleteGroup("fred"));
-    Assertions.assertThrowsExactly(NotImplementedException.class, () -> testIdentityLookup.createUser("fred", "", null));
+    Assertions.assertThrowsExactly(NotImplementedException.class, () -> testIdentityLookup.createUser("fred", new char[0], null));
     Assertions.assertThrowsExactly(NotImplementedException.class, () -> testIdentityLookup.deleteUser("fred"));
     Assertions.assertThrowsExactly(NotImplementedException.class, () -> testIdentityLookup.updateGroup(null));
 

--- a/src/test/java/io/mapsmessaging/security/identity/BaseIdentityTest.java
+++ b/src/test/java/io/mapsmessaging/security/identity/BaseIdentityTest.java
@@ -17,6 +17,7 @@
 package io.mapsmessaging.security.identity;
 
 import io.mapsmessaging.configuration.ConfigurationProperties;
+import io.mapsmessaging.security.passwords.PasswordBuffer;
 import java.io.IOException;
 import java.security.GeneralSecurityException;
 import java.util.List;
@@ -51,8 +52,8 @@ public class BaseIdentityTest {
     }
 
     @Override
-    public char[] getPasswordHash(String username) throws IOException, GeneralSecurityException {
-      return new char[0];
+    public PasswordBuffer getPasswordHash(String username) throws IOException, GeneralSecurityException {
+      return new PasswordBuffer(new char[0]);
     }
 
     @Override

--- a/src/test/java/io/mapsmessaging/security/identity/impl/ApacheIdentifierTest.java
+++ b/src/test/java/io/mapsmessaging/security/identity/impl/ApacheIdentifierTest.java
@@ -21,6 +21,7 @@ import io.mapsmessaging.security.identity.IdentityLookup;
 import io.mapsmessaging.security.identity.IdentityLookupFactory;
 import io.mapsmessaging.security.identity.NoSuchUserFoundException;
 import io.mapsmessaging.security.identity.impl.apache.ApacheBasicAuth;
+import io.mapsmessaging.security.passwords.PasswordBuffer;
 import io.mapsmessaging.security.passwords.PasswordHandler;
 import io.mapsmessaging.security.passwords.PasswordHandlerFactory;
 import io.mapsmessaging.security.passwords.hashes.md5.Md5PasswordHasher;
@@ -42,15 +43,15 @@ class ApacheIdentifierTest {
     Assertions.assertEquals("apache", lookup.getDomain());
     Assertions.assertEquals("Apache-Basic-Auth", lookup.getName());
 
-    char[] hash = lookup.getPasswordHash("test");
+    PasswordBuffer hash = lookup.getPasswordHash("test");
     Assertions.assertNotNull(hash);
-    Assertions.assertNotEquals(0, hash.length);
+    Assertions.assertNotEquals(0, hash.getHash().length);
     Assertions.assertNotNull(lookup.findGroup("user"));
     Assertions.assertNull(lookup.findGroup("user1"));
 
-    String pwd = new String(hash);
+    String pwd = new String(hash.getHash());
     Assertions.assertEquals("$apr1$9r.m87gj$5wXLLFhGKzknbwSLJj0HC1", pwd);
-    PasswordHandler passwordHasher = PasswordHandlerFactory.getInstance().parse(hash);
+    PasswordHandler passwordHasher = PasswordHandlerFactory.getInstance().parse(hash.getHash());
     Assertions.assertEquals(Md5PasswordHasher.class, passwordHasher.getClass());
   }
 

--- a/src/test/java/io/mapsmessaging/security/identity/impl/ApacheIdentifierTest.java
+++ b/src/test/java/io/mapsmessaging/security/identity/impl/ApacheIdentifierTest.java
@@ -50,7 +50,7 @@ class ApacheIdentifierTest {
 
     String pwd = new String(hash);
     Assertions.assertEquals("$apr1$9r.m87gj$5wXLLFhGKzknbwSLJj0HC1", pwd);
-    PasswordHandler passwordHasher = PasswordHandlerFactory.getInstance().parse(pwd);
+    PasswordHandler passwordHasher = PasswordHandlerFactory.getInstance().parse(hash);
     Assertions.assertEquals(Md5PasswordHasher.class, passwordHasher.getClass());
   }
 

--- a/src/test/java/io/mapsmessaging/security/identity/impl/EncryptedAuthTest.java
+++ b/src/test/java/io/mapsmessaging/security/identity/impl/EncryptedAuthTest.java
@@ -21,6 +21,7 @@ import io.mapsmessaging.security.identity.IdentityEntry;
 import io.mapsmessaging.security.identity.IdentityLookupFactory;
 import io.mapsmessaging.security.identity.PasswordGenerator;
 import io.mapsmessaging.security.identity.impl.encrypted.EncryptedAuth;
+import io.mapsmessaging.security.passwords.PasswordBuffer;
 import java.io.File;
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -67,8 +68,8 @@ public class EncryptedAuthTest  {
 
     for (String user : users.keySet()) {
       IdentityEntry entry = auth.findEntry(user);
-      char[] pass = entry.getPassword();
-      Assertions.assertArrayEquals(pass, users.get(user));
+      PasswordBuffer pass = entry.getPassword();
+      Assertions.assertArrayEquals(pass.getHash(), users.get(user));
     }
   }
 
@@ -102,7 +103,7 @@ public class EncryptedAuthTest  {
 
     for (String user : users.keySet()) {
       IdentityEntry entry = auth.findEntry(user);
-      char[] pass = entry.getPassword();
+      char[] pass = entry.getPassword().getHash();
       Assertions.assertArrayEquals(pass, users.get(user));
     }
 

--- a/src/test/java/io/mapsmessaging/security/identity/impl/EncryptedAuthTest.java
+++ b/src/test/java/io/mapsmessaging/security/identity/impl/EncryptedAuthTest.java
@@ -57,18 +57,18 @@ public class EncryptedAuthTest  {
     EncryptedAuth auth = (EncryptedAuth) IdentityLookupFactory.getInstance().get("Encrypted-Auth", baseMap);
 
     Faker faker = new Faker();
-    Map<String, String> users = new LinkedHashMap<>();
+    Map<String, char[]> users = new LinkedHashMap<>();
     for (int x = 0; x < 100; x++) {
       String username = faker.name().username();
-      String password = PasswordGenerator.generateSalt(20);
+      char[] password = PasswordGenerator.generateSalt(20).toCharArray();
       users.put(username, password);
       auth.createUser(username, password, auth.getPasswordHandler());
     }
 
     for (String user : users.keySet()) {
       IdentityEntry entry = auth.findEntry(user);
-      String pass = entry.getPassword();
-      Assertions.assertEquals(pass, users.get(user));
+      char[] pass = entry.getPassword();
+      Assertions.assertArrayEquals(pass, users.get(user));
     }
   }
 
@@ -92,18 +92,18 @@ public class EncryptedAuthTest  {
     EncryptedAuth auth = (EncryptedAuth) IdentityLookupFactory.getInstance().get("Encrypted-Auth", baseMap);
 
     Faker faker = new Faker();
-    Map<String, String> users = new LinkedHashMap<>();
+    Map<String, char[]> users = new LinkedHashMap<>();
     for (int x = 0; x < 100; x++) {
       String username = faker.name().username();
-      String password = PasswordGenerator.generateSalt(20);
+      char[] password = PasswordGenerator.generateSalt(20).toCharArray();
       users.put(username, password);
       auth.createUser(username, password, auth.getPasswordHandler());
     }
 
     for (String user : users.keySet()) {
       IdentityEntry entry = auth.findEntry(user);
-      String pass = entry.getPassword();
-      Assertions.assertEquals(pass, users.get(user));
+      char[] pass = entry.getPassword();
+      Assertions.assertArrayEquals(pass, users.get(user));
     }
 
     EncryptedAuth auth2 = (EncryptedAuth) IdentityLookupFactory.getInstance().get("Encrypted-Auth", baseMap);

--- a/src/test/java/io/mapsmessaging/security/identity/impl/LdapIdentifierTest.java
+++ b/src/test/java/io/mapsmessaging/security/identity/impl/LdapIdentifierTest.java
@@ -71,7 +71,7 @@ public class LdapIdentifierTest {
     Assertions.assertNotEquals(0, hash.length);
     String pwd = new String(hash);
     Assertions.assertEquals(properties.getProperty("hashedPassword"), pwd);
-    PasswordHandler passwordHasher = PasswordHandlerFactory.getInstance().parse(pwd);
+    PasswordHandler passwordHasher = PasswordHandlerFactory.getInstance().parse(hash);
     Assertions.assertEquals(Md5UnixPasswordHasher.class, passwordHasher.getClass());
     IdentityEntry identityEntry = lookup.findEntry(properties.getProperty("username"));
     Assertions.assertNotNull(identityEntry);

--- a/src/test/java/io/mapsmessaging/security/identity/impl/LdapIdentifierTest.java
+++ b/src/test/java/io/mapsmessaging/security/identity/impl/LdapIdentifierTest.java
@@ -22,6 +22,7 @@ import io.mapsmessaging.security.identity.IdentityLookupFactory;
 import io.mapsmessaging.security.identity.impl.ldap.LdapAuth;
 import io.mapsmessaging.security.identity.impl.ldap.LdapUser;
 import io.mapsmessaging.security.jaas.PropertiesLoader;
+import io.mapsmessaging.security.passwords.PasswordBuffer;
 import io.mapsmessaging.security.passwords.PasswordHandler;
 import io.mapsmessaging.security.passwords.PasswordHandlerFactory;
 import io.mapsmessaging.security.passwords.hashes.md5.Md5UnixPasswordHasher;
@@ -66,12 +67,12 @@ public class LdapIdentifierTest {
     Assertions.assertEquals(lookup.getClass(), LdapAuth.class);
     Assertions.assertEquals("ldap", lookup.getDomain());
 
-    char[] hash = lookup.getPasswordHash(properties.getProperty("username"));
+    PasswordBuffer hash = lookup.getPasswordHash(properties.getProperty("username"));
     Assertions.assertNotNull(hash);
-    Assertions.assertNotEquals(0, hash.length);
-    String pwd = new String(hash);
+    Assertions.assertNotEquals(0, hash.getHash().length);
+    String pwd = new String(hash.getHash());
     Assertions.assertEquals(properties.getProperty("hashedPassword"), pwd);
-    PasswordHandler passwordHasher = PasswordHandlerFactory.getInstance().parse(hash);
+    PasswordHandler passwordHasher = PasswordHandlerFactory.getInstance().parse(hash.getHash());
     Assertions.assertEquals(Md5UnixPasswordHasher.class, passwordHasher.getClass());
     IdentityEntry identityEntry = lookup.findEntry(properties.getProperty("username"));
     Assertions.assertNotNull(identityEntry);

--- a/src/test/java/io/mapsmessaging/security/identity/impl/UnixIdentifierTest.java
+++ b/src/test/java/io/mapsmessaging/security/identity/impl/UnixIdentifierTest.java
@@ -21,6 +21,7 @@ import io.mapsmessaging.security.identity.IdentityLookup;
 import io.mapsmessaging.security.identity.IdentityLookupFactory;
 import io.mapsmessaging.security.identity.NoSuchUserFoundException;
 import io.mapsmessaging.security.identity.impl.unix.UnixAuth;
+import io.mapsmessaging.security.passwords.PasswordBuffer;
 import io.mapsmessaging.security.passwords.PasswordHandler;
 import io.mapsmessaging.security.passwords.PasswordHandlerFactory;
 import io.mapsmessaging.security.passwords.hashes.sha.UnixSha512PasswordHasher;
@@ -43,12 +44,12 @@ class UnixIdentifierTest {
     Assertions.assertNull(lookup.findGroup("admin"));
     Assertions.assertEquals(lookup.getDomain(), "unix");
     Assertions.assertEquals(lookup.getClass(), UnixAuth.class);
-    char[] hash = lookup.getPasswordHash("test");
+    PasswordBuffer hash = lookup.getPasswordHash("test");
     Assertions.assertNotNull(hash);
-    Assertions.assertNotEquals(0, hash.length);
-    String pwd = new String(hash);
+    Assertions.assertNotEquals(0, hash.getHash().length);
+    String pwd = new String(hash.getHash());
     Assertions.assertEquals("$6$DVW4laGf$QwTuOOtd.1G3u2fs8d5/OtcQ73qTbwA.oAC1XWTmkkjrvDLEJ2WweTcBdxRkzfjQVfZCw3OVVBAMsIGMkH3On/", pwd);
-    PasswordHandler passwordHasher = PasswordHandlerFactory.getInstance().parse(hash);
+    PasswordHandler passwordHasher = PasswordHandlerFactory.getInstance().parse(hash.getHash());
     Assertions.assertEquals(UnixSha512PasswordHasher.class, passwordHasher.getClass());
   }
 
@@ -63,7 +64,7 @@ class UnixIdentifierTest {
     Assertions.assertNull(lookup.findGroup("admin"));
     Assertions.assertEquals(lookup.getDomain(), "unix");
     Assertions.assertEquals(lookup.getClass(), UnixAuth.class);
-    char[] hash = lookup.getPasswordHash("test");
+    char[] hash = lookup.getPasswordHash("test").getHash();
     Assertions.assertNotNull(hash);
     Assertions.assertNotEquals(0, hash.length);
     String pwd = new String(hash);

--- a/src/test/java/io/mapsmessaging/security/identity/impl/UnixIdentifierTest.java
+++ b/src/test/java/io/mapsmessaging/security/identity/impl/UnixIdentifierTest.java
@@ -48,7 +48,7 @@ class UnixIdentifierTest {
     Assertions.assertNotEquals(0, hash.length);
     String pwd = new String(hash);
     Assertions.assertEquals("$6$DVW4laGf$QwTuOOtd.1G3u2fs8d5/OtcQ73qTbwA.oAC1XWTmkkjrvDLEJ2WweTcBdxRkzfjQVfZCw3OVVBAMsIGMkH3On/", pwd);
-    PasswordHandler passwordHasher = PasswordHandlerFactory.getInstance().parse(pwd);
+    PasswordHandler passwordHasher = PasswordHandlerFactory.getInstance().parse(hash);
     Assertions.assertEquals(UnixSha512PasswordHasher.class, passwordHasher.getClass());
   }
 
@@ -68,7 +68,7 @@ class UnixIdentifierTest {
     Assertions.assertNotEquals(0, hash.length);
     String pwd = new String(hash);
     Assertions.assertEquals("$6$DVW4laGf$QwTuOOtd.1G3u2fs8d5/OtcQ73qTbwA.oAC1XWTmkkjrvDLEJ2WweTcBdxRkzfjQVfZCw3OVVBAMsIGMkH3On/", pwd);
-    PasswordHandler passwordHasher = PasswordHandlerFactory.getInstance().parse(pwd);
+    PasswordHandler passwordHasher = PasswordHandlerFactory.getInstance().parse(hash);
     Assertions.assertEquals(UnixSha512PasswordHasher.class, passwordHasher.getClass());
   }
 

--- a/src/test/java/io/mapsmessaging/security/identity/parsers/BCryptTest.java
+++ b/src/test/java/io/mapsmessaging/security/identity/parsers/BCryptTest.java
@@ -24,12 +24,12 @@ class BCryptTest extends BaseHashFunctions {
 
   @Test
   void checkBcryptHash() throws GeneralSecurityException, IOException {
-    testHashing("$2y$10$BzVXd/hbkglo7bRLVZwYEu/45Uy24FsoZBHEaJqi690AJzIOV/Q5u", "This is an bcrypt password");
+    testHashing("$2y$10$BzVXd/hbkglo7bRLVZwYEu/45Uy24FsoZBHEaJqi690AJzIOV/Q5u", "This is an bcrypt password".toCharArray());
   }
 
   @Test
   void checkBcryptHashWrongPassword() throws GeneralSecurityException, IOException {
-    testHashing("$2y$10$BzVXd/hbkglo7bRLVZwYEu/45Uy24FsoZBHEaJqi690AJzIOV/Q5u", "This is a wrong password", false);
+    testHashing("$2y$10$BzVXd/hbkglo7bRLVZwYEu/45Uy24FsoZBHEaJqi690AJzIOV/Q5u", "This is a wrong password".toCharArray(), false);
   }
 
 }

--- a/src/test/java/io/mapsmessaging/security/identity/parsers/BaseHashFunctions.java
+++ b/src/test/java/io/mapsmessaging/security/identity/parsers/BaseHashFunctions.java
@@ -19,37 +19,36 @@ package io.mapsmessaging.security.identity.parsers;
 import io.mapsmessaging.security.passwords.PasswordHandler;
 import io.mapsmessaging.security.passwords.PasswordHandlerFactory;
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import java.security.GeneralSecurityException;
 import java.util.Arrays;
 import org.junit.jupiter.api.Assertions;
 
 public class BaseHashFunctions {
 
-  protected void testHashing(String passwordHashString, String rawPassword)
+  protected void testHashing(String passwordHashString, char[] rawPassword)
       throws GeneralSecurityException, IOException {
     testHashing(passwordHashString, rawPassword, true);
   }
 
-  protected void testHashing(String passwordHashString, String rawPassword, boolean shouldPass)
+  protected void testHashing(String passwordHashString, char[] rawPassword, boolean shouldPass)
       throws GeneralSecurityException, IOException {
     //
     // We parse the password string to extract the public SALT, so we can pass to the client
     //
-    PasswordHandler passwordHasher = PasswordHandlerFactory.getInstance().parse(passwordHashString);
+    PasswordHandler passwordHasher = PasswordHandlerFactory.getInstance().parse(passwordHashString.toCharArray());
 
     // This would be done on the client side of this
-    byte[] hash =
+    char[] hash =
         passwordHasher.transformPassword(
-            rawPassword.getBytes(StandardCharsets.UTF_8),
+            rawPassword,
             passwordHasher.getSalt(),
             passwordHasher.getCost());
 
     // The result should be that the hash = password + salt hashed should match what the server has
     if (shouldPass) {
-      Assertions.assertArrayEquals(passwordHashString.getBytes(StandardCharsets.UTF_8), hash);
+      Assertions.assertArrayEquals(passwordHashString.toCharArray(), hash);
     } else {
-      Assertions.assertFalse(Arrays.equals(passwordHashString.getBytes(StandardCharsets.UTF_8), hash));
+      Assertions.assertFalse(Arrays.equals(passwordHashString.toCharArray(), hash));
     }
   }
 

--- a/src/test/java/io/mapsmessaging/security/identity/parsers/Md5Test.java
+++ b/src/test/java/io/mapsmessaging/security/identity/parsers/Md5Test.java
@@ -24,12 +24,12 @@ class Md5Test extends BaseHashFunctions {
 
   @Test
   void checkMd5Hash() throws GeneralSecurityException, IOException {
-    testHashing("$apr1$po9cazbx$JG5SMaTSVYrtFlYQb821M.", "This is an md5 password");
+    testHashing("$apr1$po9cazbx$JG5SMaTSVYrtFlYQb821M.", "This is an md5 password".toCharArray());
   }
 
   @Test
   void checkMd5HashWithBadPassword() throws GeneralSecurityException, IOException {
-    testHashing("$apr1$po9cazbx$JG5SMaTSVYrtFlYQb821M.", "This is wrong", false);
+    testHashing("$apr1$po9cazbx$JG5SMaTSVYrtFlYQb821M.", "This is wrong".toCharArray(), false);
   }
 
 }

--- a/src/test/java/io/mapsmessaging/security/identity/parsers/SimpleHashingTest.java
+++ b/src/test/java/io/mapsmessaging/security/identity/parsers/SimpleHashingTest.java
@@ -161,7 +161,7 @@ public class SimpleHashingTest {
     Assertions.assertEquals(handler.getClass(), lookup.getClass());
     Assertions.assertArrayEquals(handler.getSalt(), lookup.getSalt());
     Assertions.assertEquals(handler.getCost(), lookup.getCost());
-    Assertions.assertArrayEquals(handler.getPassword(), lookup.getPassword());
+    Assertions.assertArrayEquals(handler.getPassword().getHash(), lookup.getPassword().getHash());
     Assertions.assertEquals(handler.getKey(), lookup.getKey());
 
   }
@@ -190,7 +190,7 @@ public class SimpleHashingTest {
     Assertions.assertEquals(handler.getClass(), lookup.getClass());
     Assertions.assertArrayEquals(handler.getSalt(), lookup.getSalt());
     Assertions.assertEquals(handler.getCost(), lookup.getCost());
-    Assertions.assertArrayEquals(handler.getPassword(), lookup.getPassword());
+    Assertions.assertArrayEquals(handler.getPassword().getHash(), lookup.getPassword().getHash());
     Assertions.assertEquals(handler.getKey(), lookup.getKey());
   }
 

--- a/src/test/java/io/mapsmessaging/security/identity/parsers/SimpleHashingTest.java
+++ b/src/test/java/io/mapsmessaging/security/identity/parsers/SimpleHashingTest.java
@@ -24,6 +24,7 @@ import io.mapsmessaging.security.passwords.hashes.multi.MultiPasswordHasher;
 import io.mapsmessaging.security.passwords.hashes.pbkdf2.Pbkdf2PasswordHasher;
 import io.mapsmessaging.security.passwords.hashes.plain.PlainPasswordHasher;
 import io.mapsmessaging.security.passwords.hashes.sha.Sha1PasswordHasher;
+import io.mapsmessaging.security.util.ArrayHelper;
 import java.io.BufferedReader;
 import java.io.FileOutputStream;
 import java.io.FileReader;
@@ -70,13 +71,13 @@ public class SimpleHashingTest {
 
     List<PasswordHandler> parsers = knownParsers().collect(Collectors.toList());
     MultiPasswordHasher parser = new MultiPasswordHasher(parsers);
-    byte[] hash = parser.transformPassword(password.getBytes(StandardCharsets.UTF_8), salt.getBytes(StandardCharsets.UTF_8), 0);
+    char[] hash = parser.transformPassword(password.toCharArray(), salt.getBytes(StandardCharsets.UTF_8), 0);
     String storeHash = new String(hash);
-    PasswordHandler lookup = PasswordHandlerFactory.getInstance().parse(new String(hash));
+    PasswordHandler lookup = PasswordHandlerFactory.getInstance().parse(hash);
     Assertions.assertEquals(lookup.getClass().toString(), parser.getClass().toString());
-    byte[] computed =
+    char[] computed =
         lookup.transformPassword(
-            generatePassword(16).getBytes(StandardCharsets.UTF_8),
+            generatePassword(16).toCharArray(),
             PasswordGenerator.generateSalt(16).getBytes(StandardCharsets.UTF_8),
             0);
     String computedString = new String(computed);
@@ -89,18 +90,18 @@ public class SimpleHashingTest {
       throws GeneralSecurityException, IOException {
     String password = generatePassword(16);
     String salt = PasswordGenerator.generateSalt(16);
-    PasswordHandler parser = base.create("");
-    byte[] hash =
+    PasswordHandler parser = base.create(new char[0]);
+    char[] hash =
         parser.transformPassword(
-            password.getBytes(StandardCharsets.UTF_8),
+            password.toCharArray(),
             salt.getBytes(StandardCharsets.UTF_8),
             parser.getCost());
     String storeHash = new String(hash);
-    PasswordHandler lookup = PasswordHandlerFactory.getInstance().parse(storeHash);
+    PasswordHandler lookup = PasswordHandlerFactory.getInstance().parse(hash);
     Assertions.assertEquals(lookup.getClass().toString(), parser.getClass().toString());
-    byte[] computed =
+    char[] computed =
         lookup.transformPassword(
-            generatePassword(16).getBytes(StandardCharsets.UTF_8),
+            generatePassword(16).toCharArray(),
             lookup.getSalt(),
             lookup.getCost());
     String computedString = new String(computed);
@@ -116,18 +117,18 @@ public class SimpleHashingTest {
   void testHashAndValidate(PasswordHasher base) throws GeneralSecurityException, IOException {
     String password = generatePassword(16);
     String salt = PasswordGenerator.generateSalt(16);
-    PasswordHandler parser = base.create("");
-    byte[] hash =
+    PasswordHandler parser = base.create(new char[0]);
+    char[] hash =
         parser.transformPassword(
-            password.getBytes(StandardCharsets.UTF_8),
+            password.toCharArray(),
             salt.getBytes(StandardCharsets.UTF_8),
             parser.getCost());
     String storeHash = new String(hash);
-    PasswordHandler lookup = PasswordHandlerFactory.getInstance().parse(storeHash);
+    PasswordHandler lookup = PasswordHandlerFactory.getInstance().parse(hash);
     Assertions.assertEquals(lookup.getClass().toString(), parser.getClass().toString());
-    byte[] computed =
+    char[] computed =
         lookup.transformPassword(
-            password.getBytes(StandardCharsets.UTF_8), lookup.getSalt(), lookup.getCost());
+            password.toCharArray(), lookup.getSalt(), lookup.getCost());
     String computedString = new String(computed);
     Assertions.assertEquals(storeHash, computedString);
   }
@@ -138,16 +139,16 @@ public class SimpleHashingTest {
   void testSaltedHashAndValidate(PasswordHasher base) throws GeneralSecurityException, IOException {
     String password = generatePassword(16);
     String salt = PasswordGenerator.generateSalt(16);
-    PasswordHandler parser = base.create("");
-    byte[] hash =
+    PasswordHandler parser = base.create(new char[0]);
+    char[] hash =
         parser.transformPassword(
-            password.getBytes(StandardCharsets.UTF_8),
+            password.toCharArray(),
             salt.getBytes(StandardCharsets.UTF_8),
             parser.getCost());
     String storeHash = new String(hash);
-    PasswordHandler lookup = PasswordHandlerFactory.getInstance().parse(storeHash);
+    PasswordHandler lookup = PasswordHandlerFactory.getInstance().parse(hash);
     Assertions.assertEquals(lookup.getClass().toString(), parser.getClass().toString());
-    byte[] computed = lookup.transformPassword(password.getBytes(StandardCharsets.UTF_8), lookup.getSalt(), lookup.getCost());
+    char[] computed = lookup.transformPassword(password.toCharArray(), lookup.getSalt(), lookup.getCost());
     String computedString = new String(computed);
     Assertions.assertEquals(storeHash, computedString);
     Assertions.assertTrue(lookup.hasSalt());
@@ -156,7 +157,7 @@ public class SimpleHashingTest {
 
 
     String hashed = new String(lookup.getFullPasswordHash());
-    PasswordHandler handler = PasswordHandlerFactory.getInstance().parse(hashed);
+    PasswordHandler handler = PasswordHandlerFactory.getInstance().parse(hashed.toCharArray());
     Assertions.assertEquals(handler.getClass(), lookup.getClass());
     Assertions.assertArrayEquals(handler.getSalt(), lookup.getSalt());
     Assertions.assertEquals(handler.getCost(), lookup.getCost());
@@ -170,22 +171,22 @@ public class SimpleHashingTest {
   void testUnSaltedHashAndValidate(PasswordHasher base) throws GeneralSecurityException, IOException {
     String password = generatePassword(16);
     String salt = PasswordGenerator.generateSalt(16);
-    PasswordHandler parser = base.create("");
-    byte[] hash =
+    PasswordHandler parser = base.create(new char[0]);
+    char[] hash =
         parser.transformPassword(
-            password.getBytes(StandardCharsets.UTF_8),
+            password.toCharArray(),
             salt.getBytes(StandardCharsets.UTF_8),
             parser.getCost());
     String storeHash = new String(hash);
-    PasswordHandler lookup = PasswordHandlerFactory.getInstance().parse(storeHash);
+    PasswordHandler lookup = PasswordHandlerFactory.getInstance().parse(hash);
     Assertions.assertEquals(lookup.getClass().toString(), parser.getClass().toString());
-    byte[] computed = lookup.transformPassword(password.getBytes(StandardCharsets.UTF_8), lookup.getSalt(), lookup.getCost());
+    char[] computed = lookup.transformPassword(password.toCharArray(), lookup.getSalt(), lookup.getCost());
     String computedString = new String(computed);
     Assertions.assertEquals(storeHash, computedString);
     Assertions.assertFalse(lookup.hasSalt());
     Assertions.assertEquals(0, lookup.getSalt().length);
     String hashed = new String(lookup.getFullPasswordHash());
-    PasswordHandler handler = PasswordHandlerFactory.getInstance().parse(hashed);
+    PasswordHandler handler = PasswordHandlerFactory.getInstance().parse(hashed.toCharArray());
     Assertions.assertEquals(handler.getClass(), lookup.getClass());
     Assertions.assertArrayEquals(handler.getSalt(), lookup.getSalt());
     Assertions.assertEquals(handler.getCost(), lookup.getCost());
@@ -199,14 +200,13 @@ public class SimpleHashingTest {
     FileOutputStream fileOutputStream = new FileOutputStream("hash.txt", false);
     String password = generatePassword(16);
     String salt = PasswordGenerator.generateSalt(16);
-    PasswordHandler parser = base.create("");
-    byte[] hash =
+    PasswordHandler parser = base.create(new char[0]);
+    char[] hash =
         parser.transformPassword(
-            password.getBytes(StandardCharsets.UTF_8),
+            password.toCharArray(),
             salt.getBytes(StandardCharsets.UTF_8),
             parser.getCost());
-    String storeHash = new String(hash);
-    fileOutputStream.write(hash);
+    fileOutputStream.write(ArrayHelper.charArrayToByteArray(hash));
     fileOutputStream.write("\n".getBytes(StandardCharsets.UTF_8));
     fileOutputStream.close();
 
@@ -221,11 +221,11 @@ public class SimpleHashingTest {
       e.printStackTrace();
     }
     for (String received : hashes) {
-      PasswordHandler lookup = PasswordHandlerFactory.getInstance().parse(received);
-      byte[] computed =
+      PasswordHandler lookup = PasswordHandlerFactory.getInstance().parse(received.toCharArray());
+      char[] computed =
           lookup.transformPassword(
-              password.getBytes(StandardCharsets.UTF_8), lookup.getSalt(), lookup.getCost());
-      Assertions.assertArrayEquals(received.getBytes(StandardCharsets.UTF_8), computed);
+              password.toCharArray(), lookup.getSalt(), lookup.getCost());
+      Assertions.assertArrayEquals(received.toCharArray(), computed);
     }
   }
 

--- a/src/test/java/io/mapsmessaging/security/identity/parsers/UnixShaTest.java
+++ b/src/test/java/io/mapsmessaging/security/identity/parsers/UnixShaTest.java
@@ -33,14 +33,14 @@ class UnixShaTest extends BaseHashFunctions {
     String password = "This is a long password that needs to be hashed";
     String salt = PasswordGenerator.generateSalt(12);
     PasswordHasher passwordHasher = new UnixSha512PasswordHasher();
-    byte[] hash =
+    char[] hash =
         passwordHasher.transformPassword(
-            password.getBytes(StandardCharsets.UTF_8), salt.getBytes(StandardCharsets.UTF_8), 5000);
+            password.toCharArray(), salt.getBytes(StandardCharsets.UTF_8), 5000);
 
-    PasswordHasher passwordCheck = new UnixSha512PasswordHasher(new String(hash));
-    byte[] check =
+    PasswordHasher passwordCheck = new UnixSha512PasswordHasher(hash);
+    char[] check =
         passwordCheck.transformPassword(
-            password.getBytes(StandardCharsets.UTF_8), passwordCheck.getSalt(), 5000);
+            password.toCharArray(), passwordCheck.getSalt(), 5000);
     Assertions.assertArrayEquals(hash, check);
   }
 
@@ -49,29 +49,29 @@ class UnixShaTest extends BaseHashFunctions {
     String password = "This is a long password that needs to be hashed";
     String salt = PasswordGenerator.generateSalt(12);
     PasswordHasher passwordHasher = new UnixSha256PasswordHasher();
-    byte[] hash =
+    char[] hash =
         passwordHasher.transformPassword(
-            password.getBytes(StandardCharsets.UTF_8), salt.getBytes(StandardCharsets.UTF_8), 5000);
+            password.toCharArray(), salt.getBytes(StandardCharsets.UTF_8), 5000);
 
-    PasswordHasher passwordCheck = new UnixSha256PasswordHasher(new String(hash));
-    byte[] check =
+    PasswordHasher passwordCheck = new UnixSha256PasswordHasher(hash);
+    char[] check =
         passwordCheck.transformPassword(
-            password.getBytes(StandardCharsets.UTF_8), passwordCheck.getSalt(), 5000);
+            password.toCharArray(), passwordCheck.getSalt(), 5000);
     Assertions.assertArrayEquals(hash, check);
   }
 
   @Test
   void checkSha512Hash() throws GeneralSecurityException, IOException {
-    testHashing("$6$DVW4laGf$QwTuOOtd.1G3u2fs8d5/OtcQ73qTbwA.oAC1XWTmkkjrvDLEJ2WweTcBdxRkzfjQVfZCw3OVVBAMsIGMkH3On/", "onewordpassword");
+    testHashing("$6$DVW4laGf$QwTuOOtd.1G3u2fs8d5/OtcQ73qTbwA.oAC1XWTmkkjrvDLEJ2WweTcBdxRkzfjQVfZCw3OVVBAMsIGMkH3On/", "onewordpassword".toCharArray());
   }
 
   @Test
   void checkSha512HashWithSpaces() throws GeneralSecurityException, IOException {
-    testHashing("$6$fiizFR2o$IQNwJXIXyQEL1ikJqvFrYGMBRiTBLnjY0OFfty9O472tWdJOY6czvUpuSDJQpzojQkLqNlP6devotoSBQCp//1", "this has spaces");
+    testHashing("$6$fiizFR2o$IQNwJXIXyQEL1ikJqvFrYGMBRiTBLnjY0OFfty9O472tWdJOY6czvUpuSDJQpzojQkLqNlP6devotoSBQCp//1", "this has spaces".toCharArray());
   }
 
   @Test
   void checkSha512HashBadPassword() throws GeneralSecurityException, IOException {
-    testHashing("$6$fiizFR2o$IQNwJXIXyQEL1ikJqvFrYGMBRiTBLnjY0OFfty9O472tWdJOY6czvUpuSDJQpzojQkLqNlP6devotoSBQCp//1", "just wrong", false);
+    testHashing("$6$fiizFR2o$IQNwJXIXyQEL1ikJqvFrYGMBRiTBLnjY0OFfty9O472tWdJOY6czvUpuSDJQpzojQkLqNlP6devotoSBQCp//1", "just wrong".toCharArray(), false);
   }
 }

--- a/src/test/java/io/mapsmessaging/security/jaas/AnonymousLoginTest.java
+++ b/src/test/java/io/mapsmessaging/security/jaas/AnonymousLoginTest.java
@@ -29,7 +29,7 @@ public class AnonymousLoginTest {
   @Test
   void simpleLoginTest() throws LoginException {
     Subject subject = new Subject();
-    ClientCallbackHandler clientCallbackHandler = new ClientCallbackHandler("", "", "");
+    ClientCallbackHandler clientCallbackHandler = new ClientCallbackHandler("", new char[0], "");
     AnonymousLoginModule module = new AnonymousLoginModule();
     module.initialize(subject, clientCallbackHandler, new LinkedHashMap<>(), new LinkedHashMap<>());
 
@@ -48,7 +48,7 @@ public class AnonymousLoginTest {
 
     // Ensure the principal is of the correct type
     Principal principal = subject.getPrincipals().iterator().next();
-    Assertions.assertTrue(principal instanceof AnonymousPrincipal, "Principal is not of type AnonymousPrincipal");
+    Assertions.assertInstanceOf(AnonymousPrincipal.class, principal, "Principal is not of type AnonymousPrincipal");
 
     // Test the functionality of AnonymousPrincipal
     AnonymousPrincipal anonymousPrincipal = (AnonymousPrincipal) principal;

--- a/src/test/java/io/mapsmessaging/security/jaas/ApacheJaasLoadTest.java
+++ b/src/test/java/io/mapsmessaging/security/jaas/ApacheJaasLoadTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright [ 2020 - 2023 ] [Matthew Buckton]
+ * Copyright [ 2020 - 2024 ] [Matthew Buckton]
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -26,8 +26,8 @@ public class ApacheJaasLoadTest extends BaseLoginModuleTest {
     return "test2";
   }
 
-  String getPassword() {
-    return "This is an md5 password";
+  char[] getPassword() {
+    return "This is an md5 password".toCharArray();
   }
 
   @Test

--- a/src/test/java/io/mapsmessaging/security/jaas/ApacheLoginTest.java
+++ b/src/test/java/io/mapsmessaging/security/jaas/ApacheLoginTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright [ 2020 - 2023 ] [Matthew Buckton]
+ * Copyright [ 2020 - 2024 ] [Matthew Buckton]
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -34,7 +34,7 @@ class ApacheLoginTest extends BaseIdentity {
   }
 
   @Override
-  String getPassword() {
-    return "This is an md5 password";
+  char[] getPassword() {
+    return "This is an md5 password".toCharArray();
   }
 }

--- a/src/test/java/io/mapsmessaging/security/jaas/Auth0IdentityLoginTest.java
+++ b/src/test/java/io/mapsmessaging/security/jaas/Auth0IdentityLoginTest.java
@@ -72,14 +72,14 @@ public class Auth0IdentityLoginTest extends BaseIdentity {
   }
 
   @Override
-  String getPassword() {
-    return "testPassword01!";
+  char[] getPassword() {
+    return "testPassword01!".toCharArray();
   }
 
   @Test
   void simpleJwtLoginTest() throws Exception {
     Auth0Client auth0Client = new Auth0Client();
-    String token = auth0Client.authenticateAndGetToken();
+    char[] token = auth0Client.authenticateAndGetToken().toCharArray();
     ClientCallbackHandler clientCallbackHandler = new ClientCallbackHandler(getUser(), token, "");
     LoginModule module = createLoginModule(clientCallbackHandler);
     Assertions.assertTrue(module.login());
@@ -102,7 +102,7 @@ public class Auth0IdentityLoginTest extends BaseIdentity {
                 .put("grant_type", "client_credentials")
                 .put("grant_type", "password") // Note: using the Resource Owner Password Grant
                 .put("username", getUser())
-                .put("password", getPassword())
+                .put("password", new String(getPassword()))
                 .toString();
 
         StringEntity entity = new StringEntity(json);

--- a/src/test/java/io/mapsmessaging/security/jaas/Auth0LoginTest.java
+++ b/src/test/java/io/mapsmessaging/security/jaas/Auth0LoginTest.java
@@ -62,7 +62,7 @@ class Auth0LoginTest {
             .body(body)
             .asString();
     JSONObject jsonObject = new JSONObject(response.getBody());
-    String access_token = jsonObject.getString("access_token");
+    char[] access_token = jsonObject.getString("access_token").toCharArray();
     ClientCallbackHandler clientCallbackHandler = new ClientCallbackHandler("oNnOEXu8CsIYYxpu56ADpfm4Ma8Z1GNt", access_token, "");
     Subject subject = new Subject();
     LoginModule loginModule = new Auth0JwtLoginModule();
@@ -74,7 +74,7 @@ class Auth0LoginTest {
 
   @Test
   void basicExceptionalidation() {
-    ClientCallbackHandler clientCallbackHandler = new ClientCallbackHandler("Auth0", "BadToken", "");
+    ClientCallbackHandler clientCallbackHandler = new ClientCallbackHandler("Auth0", "BadToken".toCharArray(), "");
     Subject subject = new Subject();
     LoginModule loginModule = new Auth0JwtLoginModule();
     loginModule.initialize(subject, clientCallbackHandler, null, getOptions());

--- a/src/test/java/io/mapsmessaging/security/jaas/BaseIdentity.java
+++ b/src/test/java/io/mapsmessaging/security/jaas/BaseIdentity.java
@@ -33,14 +33,14 @@ public abstract class BaseIdentity {
 
   abstract String getUser();
 
-  abstract String getPassword();
+  abstract char[] getPassword();
 
   String getInvalidUser() {
     return "no such user";
   }
 
-  String getInvalidPassword() {
-    return "doesn't really matter";
+  char[] getInvalidPassword() {
+    return "doesn't really matter".toCharArray();
   }
 
   LoginModule createLoginModule(CallbackHandler callbackHandler) {
@@ -82,7 +82,7 @@ public abstract class BaseIdentity {
     ClientCallbackHandler clientCallbackHandler = new ClientCallbackHandler(getUser(), getPassword(), "");
     LoginModule module = createLoginModule(clientCallbackHandler);
     Assertions.assertNotNull(module);
-    Assertions.assertTrue(module instanceof BaseLoginModule);
+    Assertions.assertInstanceOf(BaseLoginModule.class, module);
     Assertions.assertNotNull(((BaseLoginModule)module).getDomain());
   }
 

--- a/src/test/java/io/mapsmessaging/security/jaas/BaseLoginModuleTest.java
+++ b/src/test/java/io/mapsmessaging/security/jaas/BaseLoginModuleTest.java
@@ -33,7 +33,7 @@ public abstract class BaseLoginModuleTest {
 
   abstract String getUser();
 
-  abstract String getPassword();
+  abstract char[] getPassword();
 
 
   void testLoad(String jaasConfigName) throws LoginException {

--- a/src/test/java/io/mapsmessaging/security/jaas/CognitoIdentityLoginTest.java
+++ b/src/test/java/io/mapsmessaging/security/jaas/CognitoIdentityLoginTest.java
@@ -1,11 +1,11 @@
 /*
- * Copyright [ 2020 - 2023 ] [Matthew Buckton]
+ * Copyright [ 2020 - 2024 ] [Matthew Buckton]
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -17,16 +17,15 @@
 package io.mapsmessaging.security.jaas;
 
 import io.mapsmessaging.security.identity.principals.JwtPrincipal;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Test;
-
-import javax.security.auth.Subject;
 import java.io.IOException;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
+import javax.security.auth.Subject;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 public class CognitoIdentityLoginTest extends BaseIdentity {
   private static Properties properties;
@@ -70,7 +69,7 @@ public class CognitoIdentityLoginTest extends BaseIdentity {
   }
 
   @Override
-  String getPassword() {
-    return "testPassword01!";
+  char[] getPassword() {
+    return "testPassword01!".toCharArray();
   }
 }

--- a/src/test/java/io/mapsmessaging/security/jaas/CognitoLoginTest.java
+++ b/src/test/java/io/mapsmessaging/security/jaas/CognitoLoginTest.java
@@ -60,7 +60,7 @@ public class CognitoLoginTest {
     if (properties == null || properties.isEmpty()) {
       return;
     }
-    ClientCallbackHandler clientCallbackHandler = new ClientCallbackHandler("maps.test", "testPassword01!", "");
+    ClientCallbackHandler clientCallbackHandler = new ClientCallbackHandler("maps.test", "testPassword01!".toCharArray(), "");
     Subject subject = new Subject();
     AwsCognitoLoginModule loginModule = new AwsCognitoLoginModule();
     loginModule.initialize(subject, clientCallbackHandler, null, getOptions());
@@ -74,7 +74,7 @@ public class CognitoLoginTest {
     if (properties == null || properties.isEmpty()) {
       return;
     }
-    ClientCallbackHandler clientCallbackHandler = new ClientCallbackHandler("maps.test", "BadToken", "");
+    ClientCallbackHandler clientCallbackHandler = new ClientCallbackHandler("maps.test", "BadToken".toCharArray(), "");
     Subject subject = new Subject();
     LoginModule loginModule = new AwsCognitoLoginModule();
     loginModule.initialize(subject, clientCallbackHandler, null, getOptions());

--- a/src/test/java/io/mapsmessaging/security/jaas/UnixJaaxLoadTest.java
+++ b/src/test/java/io/mapsmessaging/security/jaas/UnixJaaxLoadTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright [ 2020 - 2023 ] [Matthew Buckton]
+ * Copyright [ 2020 - 2024 ] [Matthew Buckton]
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -27,8 +27,8 @@ public class UnixJaaxLoadTest extends BaseLoginModuleTest {
   }
 
   @Override
-  String getPassword() {
-    return "onewordpassword";
+  char[] getPassword() {
+    return "onewordpassword".toCharArray();
   }
 
   @Test

--- a/src/test/java/io/mapsmessaging/security/jaas/UnixLoginTest.java
+++ b/src/test/java/io/mapsmessaging/security/jaas/UnixLoginTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright [ 2020 - 2023 ] [Matthew Buckton]
+ * Copyright [ 2020 - 2024 ] [Matthew Buckton]
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -36,8 +36,8 @@ class UnixLoginTest extends BaseIdentity {
   }
 
   @Override
-  String getPassword() {
-    return "onewordpassword";
+  char[] getPassword() {
+    return "onewordpassword".toCharArray();
   }
 
 }

--- a/src/test/java/io/mapsmessaging/security/sasl/BaseSasl.java
+++ b/src/test/java/io/mapsmessaging/security/sasl/BaseSasl.java
@@ -34,7 +34,7 @@ public class BaseSasl {
   protected SaslClient saslClient;
 
   protected void createClient(String username,
-      String password,
+      char[] password,
       String[] mechanism,
       String protocol,
       String authorizationId,

--- a/src/test/java/io/mapsmessaging/security/sasl/ClientCallbackHandler.java
+++ b/src/test/java/io/mapsmessaging/security/sasl/ClientCallbackHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright [ 2020 - 2023 ] [Matthew Buckton]
+ * Copyright [ 2020 - 2024 ] [Matthew Buckton]
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -25,10 +25,10 @@ import javax.security.sasl.RealmCallback;
 public class ClientCallbackHandler  implements CallbackHandler {
 
   private final String username;
-  private final String password;
+  private final char[] password;
   private final String serverName;
 
-  public ClientCallbackHandler(String username, String password, String serverName) {
+  public ClientCallbackHandler(String username, char[] password, String serverName) {
     this.username = username;
     this.password = password;
     this.serverName = serverName;
@@ -42,7 +42,7 @@ public class ClientCallbackHandler  implements CallbackHandler {
         nc.setName(username);
       } else if (cb instanceof PasswordCallback) {
         PasswordCallback pc = (PasswordCallback) cb;
-        pc.setPassword(password.toCharArray());
+        pc.setPassword(password);
       } else if (cb instanceof RealmCallback) {
         RealmCallback rc = (RealmCallback) cb;
         rc.setText(serverName);

--- a/src/test/java/io/mapsmessaging/security/sasl/SaslTester.java
+++ b/src/test/java/io/mapsmessaging/security/sasl/SaslTester.java
@@ -38,13 +38,12 @@ public class SaslTester extends BaseSasl {
   private static final String QOP_LEVEL = "auth";
 
   public void testMechanism(
-      IdentityLookup identityLookup, String mechanism, String user, String password)
+      IdentityLookup identityLookup, String mechanism, String user, char[] password)
       throws IOException {
     Map<String, String> props = new HashMap<>();
     props.put(Sasl.QOP, QOP_LEVEL);
     createServer(identityLookup, mechanism, PROTOCOL, SERVER_NAME, props);
-    createClient(
-        user, password, new String[] {mechanism}, PROTOCOL, AUTHORIZATION_ID, SERVER_NAME, props);
+    createClient(user, password, new String[] {mechanism}, PROTOCOL, AUTHORIZATION_ID, SERVER_NAME, props);
     simpleValidation(user);
   }
 

--- a/src/test/java/io/mapsmessaging/security/sasl/ServerCallbackHandler.java
+++ b/src/test/java/io/mapsmessaging/security/sasl/ServerCallbackHandler.java
@@ -51,14 +51,14 @@ public class ServerCallbackHandler implements CallbackHandler {
         NameCallback nc = (NameCallback) cb;
         String username = nc.getDefaultName();
         try {
-          hashedPassword = identityLookup.getPasswordHash(username);
+          hashedPassword = identityLookup.getPasswordHash(username).getHash();
         } catch (GeneralSecurityException e) {
           throw new IOException(e);
         }
         PasswordHandler passwordHasher = PasswordHandlerFactory.getInstance().parse(hashedPassword);
         if (passwordHasher instanceof PlainPasswordHasher) {
           try {
-            hashedPassword = new String(passwordHasher.getPassword()).toCharArray();
+            hashedPassword = passwordHasher.getPassword().getHash();
           } catch (GeneralSecurityException e) {
             throw new IOException(e);
           }

--- a/src/test/java/io/mapsmessaging/security/sasl/SimpleSaslTest.java
+++ b/src/test/java/io/mapsmessaging/security/sasl/SimpleSaslTest.java
@@ -26,7 +26,6 @@ import io.mapsmessaging.security.identity.IdentityLookupFactory;
 import io.mapsmessaging.security.passwords.hashes.sha.Sha1PasswordHasher;
 import java.io.File;
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import java.security.GeneralSecurityException;
 import java.security.Security;
 import java.util.LinkedHashMap;
@@ -85,18 +84,18 @@ class SimpleSaslTest extends BaseSasl {
         "SCRAM-SHA3-512"
       })
   void validateSaslMechanisms(String mechanism) throws IOException, GeneralSecurityException {
-    testMechanism(mechanism, faker.backToTheFuture().character(), faker.backToTheFuture().quote());
+    testMechanism(mechanism, faker.backToTheFuture().character(), faker.backToTheFuture().quote().toCharArray());
   }
 
   void simpleWrongPasswordTest(String mechanism) {
     Sha1PasswordHasher passwordParser = new Sha1PasswordHasher();
-    byte[] password =
+    char[] password =
         passwordParser.transformPassword(
-            "This is a wrong password".getBytes(StandardCharsets.UTF_8), null, 0);
-    Assertions.assertThrowsExactly(SaslException.class, () -> testMechanism(mechanism, "fred2@google.com", new String(password)));
+            "This is a wrong password".toCharArray(), null, 0);
+    Assertions.assertThrowsExactly(SaslException.class, () -> testMechanism(mechanism, "fred2@google.com", password));
   }
 
-  void testMechanism(String mechanism, String user, String password)
+  void testMechanism(String mechanism, String user, char[] password)
       throws IOException, GeneralSecurityException {
     user = user.replaceAll(" ", "_");
     if (identityAccessManager.getUser(user) != null) {


### PR DESCRIPTION
Secure the password usage, remove string usage so all arrays can be nulled after use.
Use a direct byte buffer to keep the password in to avoid heap dump leakage of hashed passwords

Add new Array Helper to remove JSON objects and String functions to work directly on the char[]. Maybe slower than string but more secure